### PR TITLE
Fix search bar breaking landing page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -517,12 +517,12 @@ export default function Index(props) {
         }) // hasnt started search yet, return all
       : searchLunr(query, props.jamsContent.batches.filter(batch => {
           
-        if (jam.keywords.split(', ').includes('Beta')) {
+        if (batch.keywords.split(', ').includes('Beta')) {
           return false
         }
         if (
           !selectedCategories.some(keyword =>
-            jam.keywords.split(', ').includes(keyword)
+            batch.keywords.split(', ').includes(keyword)
           ) &&
           selectedCategories != ''
         ) {


### PR DESCRIPTION
Was checking out the Jams website and noticed the search bar on the landing page crashes when any input is given to it.

Lines 518-530 on `index.js` seem to be the root issue, where `jam` doesn't exist.

```
searchLunr(query, props.jamsContent.batches.filter(batch => {
          
        if (batch.keywords.split(', ').includes('Beta')) {
          return false
        }
        if (
          !selectedCategories.some(keyword =>
            batch.keywords.split(', ').includes(keyword)
          ) &&
          selectedCategories != ''
        ) {
          return false
        }
}
```

Based on the code from the same file in lines 479-516, I'm assuming this was just a keyword mistake and they meant to check `batch` instead of `jam`. I've changed it in this pull request.