### PR TITLE
 Add example jams data helper to rest of codebase

### DIFF
--- a/components/JamComponent.js
+++ b/components/JamComponent.js
@@ -1,7 +1,6 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import Icon from '@hackclub/icons'
-import { Link as ScrollLink, Element } from 'react-scroll'
 import PresentationSlider from '@/components/presentationSlider'
 import BatchPartSlider from '@/components/BatchPartSlider'
 import { MDXRemote } from 'next-mdx-remote'
@@ -23,7 +22,7 @@ import lunr from 'lunr'
 import Meta from '@hackclub/meta'
 import Head from 'next/head'
 
-export default function JamComponent({ jam, jamsContent }) {
+export default function JamComponent({ jam, jams }) {
   const submitProject = async () => {
     try {
       let slug = ""
@@ -169,10 +168,8 @@ export default function JamComponent({ jam, jamsContent }) {
     this.field('keywords')
     this.field('slug')
 
-    let concatenatedJamBatch = jamsContent.singles.concat(jamsContent.batches)
-
-    for (let jindex in concatenatedJamBatch) {
-      let jam = concatenatedJamBatch[jindex]
+    for (let jindex in jams) {
+      let jam = jams[jindex]
       this.add({
         title: jam.title,
         description: jam.description,
@@ -193,18 +190,15 @@ export default function JamComponent({ jam, jamsContent }) {
 
     let results = []
 
-    let concatenatedJamBatch = jamsContent.singles.concat(jamsContent.batches)
-
     for (let returnedquery in bestList) {
       if (bestList[returnedquery]['score'] >= precision) {
         console.log(bestList[returnedquery]['ref'])
-        results.push(concatenatedJamBatch[bestList[returnedquery]['ref']])
+        results.push(jams[bestList[returnedquery]['ref']])
       }
     }
 
     return results
   }
-
   const [query, setQuery] = useState('')
 
   return (
@@ -225,68 +219,6 @@ export default function JamComponent({ jam, jamsContent }) {
         back={jam.batch == null ? '/' : '/batch/' + jam.batch} // if no batch, back is index, otherwise it is batch page
       />
       <div sx={{ height: '5rem' }}></div>
-
-      {/* <Container as="nav" sx={{
-        maxWidth:"80rem",
-        position:"sticky",
-        top:0,
-        px:"1.5rem",
-        display:"flex",
-        alignItems:"center",
-        justifyContent:"space-between",
-        gap:"2rem",
-        bg:"rgb(255,255,255,0.50)",
-        backdropFilter:"blur(16px)",
-        zIndex: 40
-      }}>
-        <button sx={{
-          border:"none",
-          font:"inherit",
-          background:"none",
-          px:"0.625rem",
-          py:"0.25rem",
-          display:"flex",
-          alignItems:"center",
-          gap:"0.25rem",
-          color:"#993CCF",
-          borderRadius:"9999px",
-          my:"1rem",
-          ":hover": { outlineStyle:"solid", outlineColor:"#993CCF", outlineWidth:"2px" }
-        }}>
-          ← Back
-        </button>
-
-        <input 
-          sx={{
-            width:"16rem",
-            border:"none",
-            font:"inherit",
-            background:"none",
-            px:"1rem",
-            py:"0.5rem",
-            bg:"white",
-            borderRadius:"9999px",
-            outlineStyle:"solid",
-            outlineWidth:"2px",
-            outlineColor: "#d4d4d4",
-            my:"1rem",
-            ":focus": { outlineColor:"#993CCF" },
-          }}
-          placeholder="Search for Raspberry Jam"
-        />
-
-        <button sx={{
-          border:"none",
-          font:"inherit",
-          background:"none",
-          p:"0.25rem",
-          color:"#993CCF",
-          borderRadius:"9999px",
-          ":hover": { outlineStyle:"solid", outlineColor:"#993CCF", outlineWidth:"2px" }
-        }}>
-          GH
-        </button>
-      </Container> */}
 
       {/* So what this code does is checks if batch is null or not. upon null renders the singles breadcrumbs ver, upon non null renders the batch ver */}
       {jam.batch != null ? (
@@ -505,7 +437,7 @@ export default function JamComponent({ jam, jamsContent }) {
               }}
               variant="outline"
               color="#fff">
-              {jam?.keywords.split(', ')[0]}
+              {jam?.keywords?.[0]}
             </Badge>
 
             <Badge

--- a/pages/batch/[slug]/[part].js
+++ b/pages/batch/[slug]/[part].js
@@ -1,110 +1,27 @@
-import path from 'path'
-import fs from 'fs'
-import matter from 'gray-matter'
 import  serialize  from '@/components/mdSerializer'
-import { MDXRemote } from 'next-mdx-remote'
-import mdxComponents from '../../../components/mdxComponents'
-import { Container } from 'theme-ui'
-import Header from '@/components/Header'
-import JamPage from '../../jam/[slug]'
 import JamComponent from '@/components/JamComponent'
 
-function getJams(fs, directory) {
-  const filenames = fs.readdirSync(directory)
-
-  return filenames.map(filename => {
-    const fileContent = fs.readFileSync(
-      path.join(directory, filename, 'en-US.md'),
-      'utf8'
-    )
-    const { data, content } = matter(fileContent)
-
-    return {
-      ...data, // Spread the properties from the data object
-      content
-    }
-  })
-}
-
-function getBatches(fs, directory) {
-  const batchNames = fs.readdirSync(directory)
-
-  return batchNames.map(batchName => {
-    const batchDirectory = path.join(directory, batchName)
-    const readMeFileContent = fs.readFileSync(
-      path.join(batchDirectory, 'readMe', 'en-US.md'),
-      'utf8'
-    )
-    const { data: readMeData, content: readMeContent } =
-      matter(readMeFileContent)
-
-    const partsDirectory = path.join(batchDirectory)
-    const partsNames = fs
-      .readdirSync(partsDirectory)
-      .filter(part => part.startsWith('part'))
-    partsNames.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-
-    const parts = partsNames.map(partName => {
-      const partContent = fs.readFileSync(
-        path.join(partsDirectory, partName, 'en-US.md'),
-        'utf8'
-      )
-      const { data, content } = matter(partContent)
-
-      return {
-        ...data, // Spread the properties from the data object
-        content
-      }
-    })
-
-    return {
-      ...readMeData, // Spread the properties from the readMeData object
-      content: readMeContent,
-      parts
-    }
-  })
-}
-
 export async function getStaticPaths() {
-  const batchesDir = path.join(process.cwd(), 'jams', 'batches')
-  const batchNames = fs.readdirSync(batchesDir)
-
-  const paths = []
-  batchNames.forEach(batchName => {
-    const batchDirectory = path.join(batchesDir, batchName)
-    const partsDirectory = path.join(batchDirectory)
-    const partsNames = fs
-      .readdirSync(partsDirectory)
-      .filter(part => part.startsWith('part'))
-
-    partsNames.forEach(partName => {
-      paths.push({
-        params: {
-          slug: batchName,
-
-          part: partName
-        }
-      })
+  // get parts for all batches
+  const { getBatchJams } = await import('@/libs/JamsData')
+  const batches = getBatchJams()
+  const partPaths = new Set()
+  batches.forEach(batch => {
+    batch.parts.forEach(part => {
+      partPaths.add(part.path)
     })
   })
+  const paths = Array.from(partPaths)
 
   return { paths, fallback: false }
 }
 
 export async function getStaticProps({ params }) {
-  const partDirectory = path.join(
-    process.cwd(),
-    'jams',
-    'batches',
-    params.slug,
-    params.part
-  )
-
-  const partContent = fs.readFileSync(
-    path.join(partDirectory, 'en-US.md'),
-    'utf8'
-  )
-  const { data, content } = matter(partContent)
+  const { slug, part } = params
+  const { getBatchPart, getAllJams } = await import('@/libs/JamsData')
+  const jams = getAllJams()
+  const batchPart = getBatchPart(slug, part)
+  const { content } = batchPart
 
   // Correctly format the Markdown content
   const formattedContent = content.replace(/\\n/g, '\n')
@@ -115,13 +32,6 @@ export async function getStaticProps({ params }) {
 
   const regex = /^#{2}\s(.+)$/gm // Regular expression to match ## headers
 
-  const jamsDir = path.join(process.cwd(), 'jams')
-
-  const singlesDir = path.join(jamsDir, 'singles')
-
-  const singles = getJams(fs, singlesDir)
-  const batches = getBatches(fs, path.join(jamsDir, 'batches'))
-
   let match
   while ((match = regex.exec(content))) {
     headers.push(match[1])
@@ -130,19 +40,15 @@ export async function getStaticProps({ params }) {
   return {
     props: {
       part: {
-        ...data,
+        ...batchPart,
         headers,
         source: mdxSource // Replace the content property with the serialized MDX source
       },
-      jamsContent: {
-        singles,
-        batches
-      }
+      jams,
     }
   }
 }
 
-export default function PartPage({ part, jamsContent }) {
-  // console.log(part.headers)
-  return <JamComponent jamsContent={jamsContent} jam={part} />
+export default function PartPage({ part, jams }) {
+  return <JamComponent jamsContent={jams} jam={part} />
 }


### PR DESCRIPTION
This is an example of expanding the JamsData helper to the rest of the codebase. Everything should work the same with the exception of the search feature– I'm still trying to poke around with that to understand how it works.