### PR TITLE
Migrating guides.hackclub.com to jams, with a new page :D

### DIFF
--- a/guides_data/data.json
+++ b/guides_data/data.json
@@ -3,318 +3,279 @@
     "Name": "Hackpad",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/6b9c8661f5ae68437e90d14a214f899759eb30b5_image.png",
     "Description": "Make your own macropad!",
-    "Type": [
-      "Hardware",
-      "CAD & 3D Printing",
-      "Beginner"
-    ],
-    "Link": "https://blueprint.hackclub.com/hackpad"
+    "Link": "https://blueprint.hackclub.com/hackpad",
+    "Keyword": "Hardware",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "2 hours"
   },
   {
     "Name": "Blinky Board",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/766c5aee15a8c57b1bd57467f3382fc68c0a627c_unnamed.gif",
     "Description": "Make a 555 LED Chaser board otherwise known as a “Blinky Board”.",
-    "Type": [
-      "Hardware",
-      "Beginner"
-    ],
-    "Link": "https://blueprint.hackclub.com/starter-projects/blinky"
+    "Link": "https://blueprint.hackclub.com/starter-projects/blinky",
+    "Keyword": "Hardware",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "Squeak",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/303d6f71d20b857c40991b5a4a0a9e8a51d7982e_tut_0.png",
     "Description": "Make a Custom Mouse!",
-    "Type": [
-      "CAD & 3D Printing",
-      "Beginner"
-    ],
-    "Link": "https://blueprint.hackclub.com/starter-projects/squeak"
+    "Link": "https://blueprint.hackclub.com/starter-projects/squeak",
+    "Keyword": "CAD",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "2 hours"
   },
   {
     "Name": "Oscillart",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/1909dcbbef6a2c325518ef21c0b2a864b460284c_Screenshot_2025-12-09_at_3.38.36_PM.png",
     "Description": "Build a web app that uses sine waves to play the notes to your favorite songs, as well as draw art using those same frequencies",
-    "Type": [
-      "Web Development",
-      "Beginner",
-      "Intermediate"
-    ],
-    "Link": "https://oscillart.athena.hackclub.com/"
+    "Link": "https://oscillart.athena.hackclub.com/",
+    "Keyword": "Web Development",
+    "Difficulty": "Intermediate",
+    "TimeEstimate": "2 hours"
   },
   {
     "Name": "Express",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/046cbfcd93eaf65aea3ff570cedf4def19c7bd53_Screenshot_2025-12-09_at_3.37.59_PM.png",
     "Description": "Intro to Backend Programming Using Node.js & Express",
-    "Type": [
-      "Web Development",
-      "Intermediate"
-    ],
-    "Link": "https://express.athena.hackclub.com/home"
+    "Link": "https://express.athena.hackclub.com/home",
+    "Keyword": "Web Development",
+    "Difficulty": "Intermediate",
+    "TimeEstimate": "2 hours"
   },
   {
     "Name": "Tribute",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/102e519c129a8a80a7a914c11dd0eb7078d8af59_Screenshot_2025-12-09_at_3.39.02_PM.png",
     "Description": "A short guide to creating webpages",
-    "Type": [
-      "Web Development",
-      "Beginner"
-    ],
-    "Link": "https://tribute.athena.hackclub.com/"
+    "Link": "https://tribute.athena.hackclub.com/",
+    "Keyword": "Web Development",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "30 minutes"
   },
   {
     "Name": "Jumpstart",
     "Image": "https://daydream.jumpstart.hackclub.com/assets/platformlandsdemo.gif",
     "Description": "Create your own 2D platformer in Godot!",
-    "Type": [
-      "Game Development",
-      "Beginner"
-    ],
-    "Link": "https://daydream.jumpstart.hackclub.com/attendee/guide.html"
+    "Link": "https://daydream.jumpstart.hackclub.com/attendee/guide.html",
+    "Keyword": "Game Development",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "Long"
   },
   {
     "Name": "Personal Website",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9f630a1f173d441d3300a41ffd97a2459cb69ff4_Screenshot_2025-12-10_at_1.32.21_PM.png",
     "Description": "Make your first website from scratch",
-    "Type": [
-      "Web Development",
-      "Beginner"
-    ],
-    "Link": "https://workshops.hackclub.com/personal_website/"
+    "Link": "https://workshops.hackclub.com/personal_website/",
+    "Keyword": "Web Development",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "Pathfinder",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/6fb37d980f8c75f6ea7283e98df3ba092de72a5b_image.png",
     "Description": "Learn how to make a custom controller pad/eFidget (and your first PCB)",
-    "Type": [
-      "Hardware",
-      "Intermediate"
-    ],
-    "Link": "https://pathfinder.hackclub.com/"
+    "Link": "https://pathfinder.hackclub.com/",
+    "Keyword": "Hardware",
+    "Difficulty": "Intermediate",
+    "TimeEstimate": "Long"
   },
   {
     "Name": "Hermes",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/96455b23db3ab2b41028d98aec5800b80037ef6f_image.png",
     "Description": "Learn how to make a PCB with an on-board sensor that can capture and display data",
-    "Type": [
-      "Hardware",
-      "Intermediate"
-    ],
-    "Link": "https://hermes.hackclub.com/"
+    "Link": "https://hermes.hackclub.com/",
+    "Keyword": "Hardware",
+    "Difficulty": "Intermediate",
+    "TimeEstimate": "Long"
   },
   {
     "Name": "Waveform",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/462777ca0390496fc3a0f61c38f5686c6f6f1acc_image.png",
     "Description": "Learn how to make an reactive music visualizer!",
-    "Type": [
-      "Web Development",
-      "Beginner"
-    ],
-    "Link": "https://waveform.hackclub.com/tutorial"
+    "Link": "https://waveform.hackclub.com/tutorial",
+    "Keyword": "Web Development",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "Learn to Pull Requests",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/98803600c0d04dc2_image.png",
     "Description": "Draw a Dino is a quick, fun workshop where you draw your own dinosaur and learn how to submit it to an open-source GitHub repo using a pull request.",
-    "Type": [
-      "Beginner"
-    ],
-    "Link": "https://draw-dino.hackclub.com/"
+    "Link": "https://draw-dino.hackclub.com/",
+    "Keyword": "GitHub",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "15 minutes"
   },
   {
     "Name": "Linux",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/2e641c165f175da4_image.png",
     "Description": "This workshop introduces the basics of Linux and the command line, teaching participants how to navigate files, run programs, and use essential terminal tools. It’s a beginner-friendly way to get comfortable working in a Linux environment",
-    "Type": [
-      "Beginner",
-      "Command Line Interface"
-    ],
-    "Link": "https://guides.hackclub.app/index.php/Linux"
+    "Link": "https://guides.hackclub.app/index.php/Linux",
+    "Keyword": "Command Line",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "Using Hack Club AI",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/95fe506b80a8873c_image.png",
     "Description": "This workshop introduces Hack Club’s AI documentation, helping participants learn how to use Hack Club’s free AI tool for artificial intelligence",
-    "Type": [
-      "Intermediate",
-      "Beginner"
-    ],
-    "Link": "https://docs.ai.hackclub.com/"
+    "Link": "https://docs.ai.hackclub.com/",
+    "Keyword": "AI Tools",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "30 minutes"
   },
   {
     "Name": "Making Your First Commit",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/4dfb349936d306e9_athena_award_-_git_workshop.png",
     "Description": "A guide to learning and setting up GitHub, Git, VSCode, Hackatime, and Codespaces!",
-    "Type": [
-      "Beginner"
-    ],
-    "Link": "https://docs.google.com/presentation/d/1Bvlc6PLaPOWEu_K9H2rqyYPyxSbU_-iYkh6T2AW9Kf4/edit?slide=id.p#slide=id.p"
+    "Link": "https://docs.google.com/presentation/d/1Bvlc6PLaPOWEu_K9H2rqyYPyxSbU_-iYkh6T2AW9Kf4/edit?slide=id.p#slide=id.p",
+    "Keyword": "GitHub",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "30 minutes"
   },
   {
     "Name": "Boba Drops",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/17234390cb3b74c4_image.png",
     "Description": "Learn how to make a website with HTML, JavaScript, and CSS! Once you've made a site, submit it to get free boba!",
-    "Type": [
-      "Beginner",
-      "Web Development"
-    ],
-    "Link": "https://www.canva.com/design/DAGr1zQLfE4/eqe5sSP6hE9-4SZez72QFA/view?utm_content=DAGr1zQLfE4&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h25bb5bce98"
+    "Link": "https://www.canva.com/design/DAGr1zQLfE4/eqe5sSP6hE9-4SZez72QFA/view?utm_content=DAGr1zQLfE4&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h25bb5bce98",
+    "Keyword": "Web Development",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "RP2040 Devboard",
     "Image": "https://kaipereira.com/images/devboard/Pasted%20image%2020250930162537.png",
     "Description": "Learn how to create a custom Devboard using the RP2040 chip!",
-    "Type": [
-      "Hardware",
-      "Intermediate"
-    ],
-    "Link": "https://kaipereira.com/journal/build-a-devboard"
+    "Link": "https://kaipereira.com/journal/build-a-devboard",
+    "Keyword": "Hardware",
+    "Difficulty": "Intermediate",
+    "TimeEstimate": "Long"
   },
   {
     "Name": "How to Make Beautiful READMEs",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/aa0e5b70d3b6444d_image.png",
     "Description": "Learn how to make your READMEs look better!",
-    "Type": [
-      "Beginner",
-      "Hardware"
-    ],
-    "Link": "https://highway.hackclub.com/guides/beautiful-readmes"
+    "Link": "https://highway.hackclub.com/guides/beautiful-readmes",
+    "Keyword": "Hardware",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "30 minutes"
   },
   {
     "Name": "Custom Keycaps & Knobs",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/558ce7c0a4677fe6_image.png",
     "Description": "Learn how to make custom CAD keycaps and knobs for keyboards and macropads in Fusion360!",
-    "Type": [
-      "CAD & 3D Printing",
-      "Intermediate"
-    ],
-    "Link": "https://highway.hackclub.com/guides/custom-keycaps"
+    "Link": "https://highway.hackclub.com/guides/custom-keycaps",
+    "Keyword": "CAD",
+    "Difficulty": "Intermediate",
+    "TimeEstimate": "2 hours"
   },
   {
     "Name": "Riceathon",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/b4bf96a3ecfbe5c1_image.png",
     "Description": "Learn to rice your Arch Linux desktop (and maybe get some socks along the way!)",
-    "Type": [
-      "Intermediate"
-    ],
-    "Link": "https://riceathon.hackclub.com/better-guide/guide.html"
+    "Link": "https://riceathon.hackclub.com/better-guide/guide.html",
+    "Keyword": "Command Line",
+    "Difficulty": "Advanced",
+    "TimeEstimate": "2 hours"
   },
   {
     "Name": "The Zoo SvelteKit guide",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/0bc04a1846b26ed9_image.png",
     "Description": "Learn how to make a site utilizing Sveltekit!",
-    "Type": [
-      "Web Development",
-      "Intermediate"
-    ],
-    "Link": "https://github.com/hackclub/The-Zoo/blob/main/zoo.pdf"
-  },
-  {
-    "Name": "Polygon YSWS Guide",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/e48aadeab8dd4fb7_output-onlinetools.gif",
-    "Description": "Learn how to create a 3D website from scratch using Three.js!",
-    "Type": [
-      "Web Development",
-      "Intermediate"
-    ],
-    "Link": "https://docs.google.com/document/d/15haQAF_CrDK76eX_rkcP0wP0LHIMHzZbkuA0DTaHdJk/edit?tab=t.0"
+    "Link": "https://github.com/hackclub/The-Zoo/blob/main/zoo.pdf",
+    "Keyword": "Web Development",
+    "Difficulty": "Intermediate",
+    "TimeEstimate": "2 hours"
   },
   {
     "Name": "Waffles JavaScript Guide ",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9f8b612f5c0a158e_image.png",
     "Description": "Learn the basics of JavaScript!",
-    "Type": [
-      "Web Development",
-      "Beginner"
-    ],
-    "Link": "https://waffles-guide.my.canva.site/"
+    "Link": "https://waffles-guide.my.canva.site/",
+    "Keyword": "Web Development",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "Grub Tailwind CSS Guide",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/cf4d8e9d6699e96e_image.png",
     "Description": "Learn how to use Tailwind CSS!",
-    "Type": [
-      "Beginner",
-      "Web Development"
-    ],
-    "Link": "https://docs.google.com/presentation/d/e/2PACX-1vRzZoNoMDwq340x6XvRoZqSOLxQ2tJk3w-t1_hH9CI4XRNzF-34hydf4bZ1lEFX9gKyxp1ANrnfSxDR/pub?start=false&loop=false&delayms=3000&slide=id.p"
+    "Link": "https://docs.google.com/presentation/d/e/2PACX-1vRzZoNoMDwq340x6XvRoZqSOLxQ2tJk3w-t1_hH9CI4XRNzF-34hydf4bZ1lEFX9gKyxp1ANrnfSxDR/pub?start=false&loop=false&delayms=3000&slide=id.p",
+    "Keyword": "Web Development",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "BakeBuild Cookie Cutter Guide",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9236b8da5f8517d1_image.png",
     "Description": "Learn how to 3D model a cookie cutter in Onshape!",
-    "Type": [
-      "CAD & 3D Printing",
-      "Beginner"
-    ],
-    "Link": "https://jams.hackclub.com/jam/bakebuild"
+    "Link": "https://jams.hackclub.com/jam/bakebuild",
+    "Keyword": "CAD",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "Split Wireless Keyboard",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/e2caab7c07431f23_image.png",
     "Description": "Create a split wireless keyboard. Circuit board, case and all!",
-    "Type": [
-      "Hardware",
-      "Intermediate"
-    ],
-    "Link": "https://blueprint.hackclub.com/starter-projects/split-keyboard"
+    "Link": "https://blueprint.hackclub.com/starter-projects/split-keyboard",
+    "Keyword": "Hardware",
+    "Difficulty": "Intermediate",
+    "TimeEstimate": "Long"
   },
   {
     "Name": "Flight Controller",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/94d237c4d7e48eb2_image.png",
     "Description": "Create a flight controller for rockets or drones!",
-    "Type": [
-      "Hardware",
-      "Advanced"
-    ],
-    "Link": "https://blueprint.hackclub.com/starter-projects/flightcontroller"
+    "Link": "https://blueprint.hackclub.com/starter-projects/flightcontroller",
+    "Keyword": "Hardware",
+    "Difficulty": "Advanced",
+    "TimeEstimate": "Long"
   },
   {
     "Name": "Mini Midi Magic",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/710054274784eca36dca4ca7a384e5b2f1fd4c9c_image.png",
     "Description": "Build your own MIDI controller!",
-    "Type": [
-      "Hardware",
-      "Intermediate"
-    ],
-    "Link": "https://blueprint.hackclub.com/starter-projects/midi"
+    "Link": "https://blueprint.hackclub.com/starter-projects/midi",
+    "Keyword": "Hardware",
+    "Difficulty": "Intermediate",
+    "TimeEstimate": "Long"
   },
   {
     "Name": "React Tier List",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/941e3652fcbca396_image.png",
     "Description": "Learn to make a customizable tier list in React!",
-    "Type": [
-      "Web Development",
-      "Beginner"
-    ],
-    "Link": "https://jams.hackclub.com/jam/tier-list"
+    "Link": "https://jams.hackclub.com/jam/tier-list",
+    "Keyword": "Web Development",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "Solder",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/ad0f0ce4430583c1_image.png",
     "Description": "Learn the basics of KiCAD with Solder!",
-    "Type": [
-      "Hardware",
-      "Beginner"
-    ],
-    "Link": "https://solder.hackclub.com/start"
+    "Link": "https://solder.hackclub.com/start",
+    "Keyword": "Hardware",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "Reactive Guide",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/b1e818a99fa63b37_image.png",
     "Description": "Learn how to make a site in React!",
-    "Type": [
-      "Web Development",
-      "Beginner"
-    ],
-    "Link": "https://www.figma.com/slides/Gqg9is3DM3BFmlUB6yTArH/Reactive-Guide?node-id=1-42&t=EOPDBdlzxP7FCI8l-0"
+    "Link": "https://www.figma.com/slides/Gqg9is3DM3BFmlUB6yTArH/Reactive-Guide?node-id=1-42&t=EOPDBdlzxP7FCI8l-0",
+    "Keyword": "Web Development",
+    "Difficulty": "Beginner",
+    "TimeEstimate": "1 hour"
   },
   {
     "Name": "Easel Guide",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/f0ace900ea47c5ad_screenshot_20251213_173454.png",
     "Description": "Learn how to create your own programming language.",
-    "Type": [
-      "Advanced"
-    ],
-    "Link": "https://easel.hackclub.com/orpheus-finds-easel"
+    "Link": "https://easel.hackclub.com/orpheus-finds-easel",
+    "Keyword": "Programming Languages",
+    "Difficulty": "Advanced",
+    "TimeEstimate": "Long"
   }
 ]

--- a/guides_data/data.json
+++ b/guides_data/data.json
@@ -1,0 +1,320 @@
+[
+  {
+    "Name": "Hackpad",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/6b9c8661f5ae68437e90d14a214f899759eb30b5_image.png",
+    "Description": "Make your own macropad!",
+    "Type": [
+      "Hardware",
+      "CAD & 3D Printing",
+      "Beginner"
+    ],
+    "Link": "https://blueprint.hackclub.com/hackpad"
+  },
+  {
+    "Name": "Blinky Board",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/766c5aee15a8c57b1bd57467f3382fc68c0a627c_unnamed.gif",
+    "Description": "Make a 555 LED Chaser board otherwise known as a “Blinky Board”.",
+    "Type": [
+      "Hardware",
+      "Beginner"
+    ],
+    "Link": "https://blueprint.hackclub.com/starter-projects/blinky"
+  },
+  {
+    "Name": "Squeak",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/303d6f71d20b857c40991b5a4a0a9e8a51d7982e_tut_0.png",
+    "Description": "Make a Custom Mouse!",
+    "Type": [
+      "CAD & 3D Printing",
+      "Beginner"
+    ],
+    "Link": "https://blueprint.hackclub.com/starter-projects/squeak"
+  },
+  {
+    "Name": "Oscillart",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/1909dcbbef6a2c325518ef21c0b2a864b460284c_Screenshot_2025-12-09_at_3.38.36_PM.png",
+    "Description": "Build a web app that uses sine waves to play the notes to your favorite songs, as well as draw art using those same frequencies",
+    "Type": [
+      "Web Development",
+      "Beginner",
+      "Intermediate"
+    ],
+    "Link": "https://oscillart.athena.hackclub.com/"
+  },
+  {
+    "Name": "Express",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/046cbfcd93eaf65aea3ff570cedf4def19c7bd53_Screenshot_2025-12-09_at_3.37.59_PM.png",
+    "Description": "Intro to Backend Programming Using Node.js & Express",
+    "Type": [
+      "Web Development",
+      "Intermediate"
+    ],
+    "Link": "https://express.athena.hackclub.com/home"
+  },
+  {
+    "Name": "Tribute",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/102e519c129a8a80a7a914c11dd0eb7078d8af59_Screenshot_2025-12-09_at_3.39.02_PM.png",
+    "Description": "A short guide to creating webpages",
+    "Type": [
+      "Web Development",
+      "Beginner"
+    ],
+    "Link": "https://tribute.athena.hackclub.com/"
+  },
+  {
+    "Name": "Jumpstart",
+    "Image": "https://daydream.jumpstart.hackclub.com/assets/platformlandsdemo.gif",
+    "Description": "Create your own 2D platformer in Godot!",
+    "Type": [
+      "Game Development",
+      "Beginner"
+    ],
+    "Link": "https://daydream.jumpstart.hackclub.com/attendee/guide.html"
+  },
+  {
+    "Name": "Personal Website",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9f630a1f173d441d3300a41ffd97a2459cb69ff4_Screenshot_2025-12-10_at_1.32.21_PM.png",
+    "Description": "Make your first website from scratch",
+    "Type": [
+      "Web Development",
+      "Beginner"
+    ],
+    "Link": "https://workshops.hackclub.com/personal_website/"
+  },
+  {
+    "Name": "Pathfinder",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/6fb37d980f8c75f6ea7283e98df3ba092de72a5b_image.png",
+    "Description": "Learn how to make a custom controller pad/eFidget (and your first PCB)",
+    "Type": [
+      "Hardware",
+      "Intermediate"
+    ],
+    "Link": "https://pathfinder.hackclub.com/"
+  },
+  {
+    "Name": "Hermes",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/96455b23db3ab2b41028d98aec5800b80037ef6f_image.png",
+    "Description": "Learn how to make a PCB with an on-board sensor that can capture and display data",
+    "Type": [
+      "Hardware",
+      "Intermediate"
+    ],
+    "Link": "https://hermes.hackclub.com/"
+  },
+  {
+    "Name": "Waveform",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/462777ca0390496fc3a0f61c38f5686c6f6f1acc_image.png",
+    "Description": "Learn how to make an reactive music visualizer!",
+    "Type": [
+      "Web Development",
+      "Beginner"
+    ],
+    "Link": "https://waveform.hackclub.com/tutorial"
+  },
+  {
+    "Name": "Learn to Pull Requests",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/98803600c0d04dc2_image.png",
+    "Description": "Draw a Dino is a quick, fun workshop where you draw your own dinosaur and learn how to submit it to an open-source GitHub repo using a pull request.",
+    "Type": [
+      "Beginner"
+    ],
+    "Link": "https://draw-dino.hackclub.com/"
+  },
+  {
+    "Name": "Linux",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/2e641c165f175da4_image.png",
+    "Description": "This workshop introduces the basics of Linux and the command line, teaching participants how to navigate files, run programs, and use essential terminal tools. It’s a beginner-friendly way to get comfortable working in a Linux environment",
+    "Type": [
+      "Beginner",
+      "Command Line Interface"
+    ],
+    "Link": "https://guides.hackclub.app/index.php/Linux"
+  },
+  {
+    "Name": "Using Hack Club AI",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/95fe506b80a8873c_image.png",
+    "Description": "This workshop introduces Hack Club’s AI documentation, helping participants learn how to use Hack Club’s free AI tool for artificial intelligence",
+    "Type": [
+      "Intermediate",
+      "Beginner"
+    ],
+    "Link": "https://docs.ai.hackclub.com/"
+  },
+  {
+    "Name": "Making Your First Commit",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/4dfb349936d306e9_athena_award_-_git_workshop.png",
+    "Description": "A guide to learning and setting up GitHub, Git, VSCode, Hackatime, and Codespaces!",
+    "Type": [
+      "Beginner"
+    ],
+    "Link": "https://docs.google.com/presentation/d/1Bvlc6PLaPOWEu_K9H2rqyYPyxSbU_-iYkh6T2AW9Kf4/edit?slide=id.p#slide=id.p"
+  },
+  {
+    "Name": "Boba Drops",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/17234390cb3b74c4_image.png",
+    "Description": "Learn how to make a website with HTML, JavaScript, and CSS! Once you've made a site, submit it to get free boba!",
+    "Type": [
+      "Beginner",
+      "Web Development"
+    ],
+    "Link": "https://www.canva.com/design/DAGr1zQLfE4/eqe5sSP6hE9-4SZez72QFA/view?utm_content=DAGr1zQLfE4&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h25bb5bce98"
+  },
+  {
+    "Name": "RP2040 Devboard",
+    "Image": "https://kaipereira.com/images/devboard/Pasted%20image%2020250930162537.png",
+    "Description": "Learn how to create a custom Devboard using the RP2040 chip!",
+    "Type": [
+      "Hardware",
+      "Intermediate"
+    ],
+    "Link": "https://kaipereira.com/journal/build-a-devboard"
+  },
+  {
+    "Name": "How to Make Beautiful READMEs",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/aa0e5b70d3b6444d_image.png",
+    "Description": "Learn how to make your READMEs look better!",
+    "Type": [
+      "Beginner",
+      "Hardware"
+    ],
+    "Link": "https://highway.hackclub.com/guides/beautiful-readmes"
+  },
+  {
+    "Name": "Custom Keycaps & Knobs",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/558ce7c0a4677fe6_image.png",
+    "Description": "Learn how to make custom CAD keycaps and knobs for keyboards and macropads in Fusion360!",
+    "Type": [
+      "CAD & 3D Printing",
+      "Intermediate"
+    ],
+    "Link": "https://highway.hackclub.com/guides/custom-keycaps"
+  },
+  {
+    "Name": "Riceathon",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/b4bf96a3ecfbe5c1_image.png",
+    "Description": "Learn to rice your Arch Linux desktop (and maybe get some socks along the way!)",
+    "Type": [
+      "Intermediate"
+    ],
+    "Link": "https://riceathon.hackclub.com/better-guide/guide.html"
+  },
+  {
+    "Name": "The Zoo SvelteKit guide",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/0bc04a1846b26ed9_image.png",
+    "Description": "Learn how to make a site utilizing Sveltekit!",
+    "Type": [
+      "Web Development",
+      "Intermediate"
+    ],
+    "Link": "https://github.com/hackclub/The-Zoo/blob/main/zoo.pdf"
+  },
+  {
+    "Name": "Polygon YSWS Guide",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/e48aadeab8dd4fb7_output-onlinetools.gif",
+    "Description": "Learn how to create a 3D website from scratch using Three.js!",
+    "Type": [
+      "Web Development",
+      "Intermediate"
+    ],
+    "Link": "https://docs.google.com/document/d/15haQAF_CrDK76eX_rkcP0wP0LHIMHzZbkuA0DTaHdJk/edit?tab=t.0"
+  },
+  {
+    "Name": "Waffles JavaScript Guide ",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9f8b612f5c0a158e_image.png",
+    "Description": "Learn the basics of JavaScript!",
+    "Type": [
+      "Web Development",
+      "Beginner"
+    ],
+    "Link": "https://waffles-guide.my.canva.site/"
+  },
+  {
+    "Name": "Grub Tailwind CSS Guide",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/cf4d8e9d6699e96e_image.png",
+    "Description": "Learn how to use Tailwind CSS!",
+    "Type": [
+      "Beginner",
+      "Web Development"
+    ],
+    "Link": "https://docs.google.com/presentation/d/e/2PACX-1vRzZoNoMDwq340x6XvRoZqSOLxQ2tJk3w-t1_hH9CI4XRNzF-34hydf4bZ1lEFX9gKyxp1ANrnfSxDR/pub?start=false&loop=false&delayms=3000&slide=id.p"
+  },
+  {
+    "Name": "BakeBuild Cookie Cutter Guide",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9236b8da5f8517d1_image.png",
+    "Description": "Learn how to 3D model a cookie cutter in Onshape!",
+    "Type": [
+      "CAD & 3D Printing",
+      "Beginner"
+    ],
+    "Link": "https://jams.hackclub.com/jam/bakebuild"
+  },
+  {
+    "Name": "Split Wireless Keyboard",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/e2caab7c07431f23_image.png",
+    "Description": "Create a split wireless keyboard. Circuit board, case and all!",
+    "Type": [
+      "Hardware",
+      "Intermediate"
+    ],
+    "Link": "https://blueprint.hackclub.com/starter-projects/split-keyboard"
+  },
+  {
+    "Name": "Flight Controller",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/94d237c4d7e48eb2_image.png",
+    "Description": "Create a flight controller for rockets or drones!",
+    "Type": [
+      "Hardware",
+      "Advanced"
+    ],
+    "Link": "https://blueprint.hackclub.com/starter-projects/flightcontroller"
+  },
+  {
+    "Name": "Mini Midi Magic",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/710054274784eca36dca4ca7a384e5b2f1fd4c9c_image.png",
+    "Description": "Build your own MIDI controller!",
+    "Type": [
+      "Hardware",
+      "Intermediate"
+    ],
+    "Link": "https://blueprint.hackclub.com/starter-projects/midi"
+  },
+  {
+    "Name": "React Tier List",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/941e3652fcbca396_image.png",
+    "Description": "Learn to make a customizable tier list in React!",
+    "Type": [
+      "Web Development",
+      "Beginner"
+    ],
+    "Link": "https://jams.hackclub.com/jam/tier-list"
+  },
+  {
+    "Name": "Solder",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/ad0f0ce4430583c1_image.png",
+    "Description": "Learn the basics of KiCAD with Solder!",
+    "Type": [
+      "Hardware",
+      "Beginner"
+    ],
+    "Link": "https://solder.hackclub.com/start"
+  },
+  {
+    "Name": "Reactive Guide",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/b1e818a99fa63b37_image.png",
+    "Description": "Learn how to make a site in React!",
+    "Type": [
+      "Web Development",
+      "Beginner"
+    ],
+    "Link": "https://www.figma.com/slides/Gqg9is3DM3BFmlUB6yTArH/Reactive-Guide?node-id=1-42&t=EOPDBdlzxP7FCI8l-0"
+  },
+  {
+    "Name": "Easel Guide",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/f0ace900ea47c5ad_screenshot_20251213_173454.png",
+    "Description": "Learn how to create your own programming language.",
+    "Type": [
+      "Advanced"
+    ],
+    "Link": "https://easel.hackclub.com/orpheus-finds-easel"
+  }
+]

--- a/guides_data/data.json
+++ b/guides_data/data.json
@@ -1,278 +1,176 @@
 [
   {
-    "Name": "Hackpad",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/6b9c8661f5ae68437e90d14a214f899759eb30b5_image.png",
-    "Description": "Make your own macropad!",
-    "Link": "https://blueprint.hackclub.com/hackpad",
-    "Keyword": "Hardware",
-    "Difficulty": "Beginner",
-    "TimeEstimate": "2 hours"
-  },
-  {
-    "Name": "Blinky Board",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/766c5aee15a8c57b1bd57467f3382fc68c0a627c_unnamed.gif",
-    "Description": "Make a 555 LED Chaser board otherwise known as a “Blinky Board”.",
-    "Link": "https://blueprint.hackclub.com/starter-projects/blinky",
-    "Keyword": "Hardware",
-    "Difficulty": "Beginner",
-    "TimeEstimate": "1 hour"
-  },
-  {
-    "Name": "Squeak",
+    "Name": "Build Your Own Custom Mouse",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/303d6f71d20b857c40991b5a4a0a9e8a51d7982e_tut_0.png",
-    "Description": "Make a Custom Mouse!",
     "Link": "https://blueprint.hackclub.com/starter-projects/squeak",
     "Keyword": "CAD",
     "Difficulty": "Beginner",
     "TimeEstimate": "2 hours"
   },
   {
-    "Name": "Oscillart",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/1909dcbbef6a2c325518ef21c0b2a864b460284c_Screenshot_2025-12-09_at_3.38.36_PM.png",
-    "Description": "Build a web app that uses sine waves to play the notes to your favorite songs, as well as draw art using those same frequencies",
-    "Link": "https://oscillart.athena.hackclub.com/",
-    "Keyword": "Web Development",
-    "Difficulty": "Intermediate",
-    "TimeEstimate": "2 hours"
-  },
-  {
-    "Name": "Express",
+    "Name": "Learn Backend Programming in ExpressJS",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/046cbfcd93eaf65aea3ff570cedf4def19c7bd53_Screenshot_2025-12-09_at_3.37.59_PM.png",
-    "Description": "Intro to Backend Programming Using Node.js & Express",
     "Link": "https://express.athena.hackclub.com/home",
     "Keyword": "Web Development",
     "Difficulty": "Intermediate",
     "TimeEstimate": "2 hours"
   },
+
   {
-    "Name": "Tribute",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/102e519c129a8a80a7a914c11dd0eb7078d8af59_Screenshot_2025-12-09_at_3.39.02_PM.png",
-    "Description": "A short guide to creating webpages",
-    "Link": "https://tribute.athena.hackclub.com/",
-    "Keyword": "Web Development",
-    "Difficulty": "Beginner",
-    "TimeEstimate": "30 minutes"
-  },
-  {
-    "Name": "Jumpstart",
+    "Name": "Create Your Own 2D Platformer in Godot",
     "Image": "https://daydream.jumpstart.hackclub.com/assets/platformlandsdemo.gif",
-    "Description": "Create your own 2D platformer in Godot!",
     "Link": "https://daydream.jumpstart.hackclub.com/attendee/guide.html",
     "Keyword": "Game Development",
     "Difficulty": "Beginner",
     "TimeEstimate": "Long"
   },
   {
-    "Name": "Personal Website",
+    "Name": "Program Your Own Personal Site",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9f630a1f173d441d3300a41ffd97a2459cb69ff4_Screenshot_2025-12-10_at_1.32.21_PM.png",
-    "Description": "Make your first website from scratch",
     "Link": "https://workshops.hackclub.com/personal_website/",
     "Keyword": "Web Development",
     "Difficulty": "Beginner",
     "TimeEstimate": "1 hour"
   },
   {
-    "Name": "Pathfinder",
+    "Name": "Create Your Own eFidget",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/6fb37d980f8c75f6ea7283e98df3ba092de72a5b_image.png",
-    "Description": "Learn how to make a custom controller pad/eFidget (and your first PCB)",
     "Link": "https://pathfinder.hackclub.com/",
     "Keyword": "Hardware",
     "Difficulty": "Intermediate",
     "TimeEstimate": "Long"
   },
   {
-    "Name": "Hermes",
+    "Name": "Design Your First PCB With a Sensor",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/96455b23db3ab2b41028d98aec5800b80037ef6f_image.png",
-    "Description": "Learn how to make a PCB with an on-board sensor that can capture and display data",
     "Link": "https://hermes.hackclub.com/",
     "Keyword": "Hardware",
     "Difficulty": "Intermediate",
     "TimeEstimate": "Long"
   },
   {
-    "Name": "Waveform",
+    "Name": "Make Your Own Music Visualizer",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/462777ca0390496fc3a0f61c38f5686c6f6f1acc_image.png",
-    "Description": "Learn how to make an reactive music visualizer!",
     "Link": "https://waveform.hackclub.com/tutorial",
     "Keyword": "Web Development",
     "Difficulty": "Beginner",
     "TimeEstimate": "1 hour"
   },
   {
-    "Name": "Learn to Pull Requests",
+    "Name": "Learn to Make Pull Requests",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/98803600c0d04dc2_image.png",
-    "Description": "Draw a Dino is a quick, fun workshop where you draw your own dinosaur and learn how to submit it to an open-source GitHub repo using a pull request.",
     "Link": "https://draw-dino.hackclub.com/",
     "Keyword": "GitHub",
     "Difficulty": "Beginner",
     "TimeEstimate": "15 minutes"
   },
   {
-    "Name": "Linux",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/2e641c165f175da4_image.png",
-    "Description": "This workshop introduces the basics of Linux and the command line, teaching participants how to navigate files, run programs, and use essential terminal tools. It’s a beginner-friendly way to get comfortable working in a Linux environment",
-    "Link": "https://guides.hackclub.app/index.php/Linux",
-    "Keyword": "Command Line",
+    "Name": "Make Your Own Macropad",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/6b9c8661f5ae68437e90d14a214f899759eb30b5_image.png",
+    "Link": "https://blueprint.hackclub.com/hackpad",
+    "Keyword": "Hardware",
     "Difficulty": "Beginner",
-    "TimeEstimate": "1 hour"
+    "TimeEstimate": "2 hours"
   },
   {
-    "Name": "Using Hack Club AI",
+    "Name": "Learn to Use Hack Club AI",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/95fe506b80a8873c_image.png",
-    "Description": "This workshop introduces Hack Club’s AI documentation, helping participants learn how to use Hack Club’s free AI tool for artificial intelligence",
     "Link": "https://docs.ai.hackclub.com/",
     "Keyword": "AI Tools",
     "Difficulty": "Beginner",
     "TimeEstimate": "30 minutes"
   },
   {
-    "Name": "Making Your First Commit",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/4dfb349936d306e9_athena_award_-_git_workshop.png",
-    "Description": "A guide to learning and setting up GitHub, Git, VSCode, Hackatime, and Codespaces!",
-    "Link": "https://docs.google.com/presentation/d/1Bvlc6PLaPOWEu_K9H2rqyYPyxSbU_-iYkh6T2AW9Kf4/edit?slide=id.p#slide=id.p",
-    "Keyword": "GitHub",
-    "Difficulty": "Beginner",
-    "TimeEstimate": "30 minutes"
-  },
-  {
-    "Name": "Boba Drops",
+    "Name": "Code Your First Site and Get Boba",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/17234390cb3b74c4_image.png",
-    "Description": "Learn how to make a website with HTML, JavaScript, and CSS! Once you've made a site, submit it to get free boba!",
     "Link": "https://www.canva.com/design/DAGr1zQLfE4/eqe5sSP6hE9-4SZez72QFA/view?utm_content=DAGr1zQLfE4&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h25bb5bce98",
     "Keyword": "Web Development",
     "Difficulty": "Beginner",
     "TimeEstimate": "1 hour"
   },
   {
-    "Name": "RP2040 Devboard",
+    "Name": "Make Your Own Pi Pico Clone",
     "Image": "https://kaipereira.com/images/devboard/Pasted%20image%2020250930162537.png",
-    "Description": "Learn how to create a custom Devboard using the RP2040 chip!",
     "Link": "https://kaipereira.com/journal/build-a-devboard",
     "Keyword": "Hardware",
     "Difficulty": "Intermediate",
     "TimeEstimate": "Long"
   },
   {
-    "Name": "How to Make Beautiful READMEs",
+    "Name": "Learn to Make Beautiful READMEs",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/aa0e5b70d3b6444d_image.png",
-    "Description": "Learn how to make your READMEs look better!",
     "Link": "https://highway.hackclub.com/guides/beautiful-readmes",
     "Keyword": "Hardware",
     "Difficulty": "Beginner",
     "TimeEstimate": "30 minutes"
   },
   {
-    "Name": "Custom Keycaps & Knobs",
+    "Name": "Design Custom Keycaps",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/558ce7c0a4677fe6_image.png",
-    "Description": "Learn how to make custom CAD keycaps and knobs for keyboards and macropads in Fusion360!",
     "Link": "https://highway.hackclub.com/guides/custom-keycaps",
     "Keyword": "CAD",
     "Difficulty": "Intermediate",
     "TimeEstimate": "2 hours"
   },
   {
-    "Name": "Riceathon",
+    "Name": "Riceathon - Customize Your Own Linux Desktop",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/b4bf96a3ecfbe5c1_image.png",
-    "Description": "Learn to rice your Arch Linux desktop (and maybe get some socks along the way!)",
     "Link": "https://riceathon.hackclub.com/better-guide/guide.html",
     "Keyword": "Command Line",
     "Difficulty": "Advanced",
     "TimeEstimate": "2 hours"
   },
   {
-    "Name": "The Zoo SvelteKit guide",
+    "Name": "The Zoo SvelteKit Guide",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/0bc04a1846b26ed9_image.png",
-    "Description": "Learn how to make a site utilizing Sveltekit!",
     "Link": "https://github.com/hackclub/The-Zoo/blob/main/zoo.pdf",
     "Keyword": "Web Development",
     "Difficulty": "Intermediate",
     "TimeEstimate": "2 hours"
   },
   {
-    "Name": "Waffles JavaScript Guide ",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9f8b612f5c0a158e_image.png",
-    "Description": "Learn the basics of JavaScript!",
-    "Link": "https://waffles-guide.my.canva.site/",
-    "Keyword": "Web Development",
-    "Difficulty": "Beginner",
-    "TimeEstimate": "1 hour"
-  },
-  {
-    "Name": "Grub Tailwind CSS Guide",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/cf4d8e9d6699e96e_image.png",
-    "Description": "Learn how to use Tailwind CSS!",
-    "Link": "https://docs.google.com/presentation/d/e/2PACX-1vRzZoNoMDwq340x6XvRoZqSOLxQ2tJk3w-t1_hH9CI4XRNzF-34hydf4bZ1lEFX9gKyxp1ANrnfSxDR/pub?start=false&loop=false&delayms=3000&slide=id.p",
-    "Keyword": "Web Development",
-    "Difficulty": "Beginner",
-    "TimeEstimate": "1 hour"
-  },
-  {
-    "Name": "BakeBuild Cookie Cutter Guide",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9236b8da5f8517d1_image.png",
-    "Description": "Learn how to 3D model a cookie cutter in Onshape!",
-    "Link": "https://jams.hackclub.com/jam/bakebuild",
-    "Keyword": "CAD",
-    "Difficulty": "Beginner",
-    "TimeEstimate": "1 hour"
-  },
-  {
-    "Name": "Split Wireless Keyboard",
+    "Name": "Create Your Own Split Keyboard",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/e2caab7c07431f23_image.png",
-    "Description": "Create a split wireless keyboard. Circuit board, case and all!",
     "Link": "https://blueprint.hackclub.com/starter-projects/split-keyboard",
     "Keyword": "Hardware",
     "Difficulty": "Intermediate",
     "TimeEstimate": "Long"
   },
   {
-    "Name": "Flight Controller",
+    "Name": "Design a Flight Controller PCB",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/94d237c4d7e48eb2_image.png",
-    "Description": "Create a flight controller for rockets or drones!",
     "Link": "https://blueprint.hackclub.com/starter-projects/flightcontroller",
     "Keyword": "Hardware",
     "Difficulty": "Advanced",
     "TimeEstimate": "Long"
   },
   {
-    "Name": "Mini Midi Magic",
+    "Name": "Make Your Own Midi Keyboard",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/710054274784eca36dca4ca7a384e5b2f1fd4c9c_image.png",
-    "Description": "Build your own MIDI controller!",
     "Link": "https://blueprint.hackclub.com/starter-projects/midi",
     "Keyword": "Hardware",
     "Difficulty": "Intermediate",
     "TimeEstimate": "Long"
   },
   {
-    "Name": "React Tier List",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/941e3652fcbca396_image.png",
-    "Description": "Learn to make a customizable tier list in React!",
-    "Link": "https://jams.hackclub.com/jam/tier-list",
-    "Keyword": "Web Development",
-    "Difficulty": "Beginner",
-    "TimeEstimate": "1 hour"
-  },
-  {
-    "Name": "Solder",
+    "Name": "Learn the Basics of KiCad & PCB Design",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/ad0f0ce4430583c1_image.png",
-    "Description": "Learn the basics of KiCAD with Solder!",
     "Link": "https://solder.hackclub.com/start",
     "Keyword": "Hardware",
     "Difficulty": "Beginner",
     "TimeEstimate": "1 hour"
   },
   {
-    "Name": "Reactive Guide",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/b1e818a99fa63b37_image.png",
-    "Description": "Learn how to make a site in React!",
-    "Link": "https://www.figma.com/slides/Gqg9is3DM3BFmlUB6yTArH/Reactive-Guide?node-id=1-42&t=EOPDBdlzxP7FCI8l-0",
-    "Keyword": "Web Development",
+    "Name": "Make a Blinky Board",
+    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/766c5aee15a8c57b1bd57467f3382fc68c0a627c_unnamed.gif",
+    "Link": "https://blueprint.hackclub.com/starter-projects/blinky",
+    "Keyword": "Hardware",
     "Difficulty": "Beginner",
     "TimeEstimate": "1 hour"
   },
   {
-    "Name": "Easel Guide",
+    "Name": "Create Your Own Programming Language",
     "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/f0ace900ea47c5ad_screenshot_20251213_173454.png",
-    "Description": "Learn how to create your own programming language.",
     "Link": "https://easel.hackclub.com/orpheus-finds-easel",
     "Keyword": "Programming Languages",
     "Difficulty": "Advanced",

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -11,7 +11,7 @@ import { useState, useEffect } from 'react'
 export default function Index(props) {
   const guides = guides_data;
 
-  const featuredGuidesList = ["Hackpad", "Riceathon", "RP2040 Devboard"]
+  const featuredGuidesList = ["Make Your Own Macropad", "Riceathon - Customize Your Own Linux Desktop", "Make Your Own Pi Pico Clone"]
   const featuredGuides = guides.filter(guide =>
     featuredGuidesList.includes(guide.Name)
   );

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -10,10 +10,13 @@ export default function Index(props) {
 
   return (
     <>
-      <Box
+        <Header
+          isHomePage={true}
+        />
+        <Box
         sx={{
           backgroundImage:
-            'linear-gradient(180deg, #993CCF 0%, rgba(170, 77, 181, 0.95) 17.19%, rgba(193, 99, 146, 0.90) 31.77%, rgba(223, 129, 101, 0.71) 52.08%, rgba(240, 146, 75, 0.60) 63.54%, rgba(240, 146, 75, 0.00) 96.88%), linear-gradient(180deg, #D9D9D9 0%, rgba(255, 255, 255, 0.00) 100%)',
+            'linear-gradient(180deg, #3C3ACF 0%, rgba(61, 111, 204, 0.95) 17.19%, rgba(78, 155, 199, 0.90) 31.77%, rgba(127, 201, 216, 0.71) 52.08%, rgba(127, 201, 216, 0.60) 63.54%, rgba(127, 201, 216, 0) 96.88%), linear-gradient(180deg, #D9D9D9 0%, rgba(255, 255, 255, 0) 100%)',
           backgroundSize: 'cover',
           color: 'white',
           display: 'flex',
@@ -86,7 +89,7 @@ export default function Index(props) {
             </Text>
           </Box>
           <Link href="/" style={{ color: 'white', fontSize: '1.3rem', fontWeight: '500' }}>
-            ← Head back to Jams
+            ← Head back to jams
           </Link>
         </Box>
       </Box>
@@ -109,7 +112,7 @@ export default function Index(props) {
               p: 0,
               zIndex: 2
             }}>
-            New to Jams? Start Jamming!
+            Not sure where to start?
           </Text>
           <Text
             as="h2"
@@ -120,7 +123,7 @@ export default function Index(props) {
               p: 0,
               zIndex: 2
             }}>
-            Here's some of the most popular Jams created by Hack Clubbers.
+            These are some favorites created for Hack Club events!
           </Text>
           <Grid
             columns={[null, '1fr', '1fr 1fr', '1fr 1fr 1fr', '1fr 1fr 1fr']}
@@ -140,14 +143,8 @@ export default function Index(props) {
             mt: '2rem',
             lineHeight: '3.5rem',
             zIndex: 2,
-            display: 'flex',
-            gap: '1rem',
-            alignItems: 'first baseline'
           }}>
-          Jams
-          <Link href="/guides" style={{ fontSize: '1.1rem', color: 'black' }}>
-            Want more? Check out the community guides →
-          </Link>
+          Guides 
         </Text>
       </Container>
 

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -48,8 +48,6 @@ export default function Index(props) {
     setFilteredGuides(filtered);
   }, [query, selectedCategories, difficulty, time]);
 
-  console.log(difficulty);
-
   return (
     <>
         <Header

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -1,0 +1,157 @@
+import Header from '@/components/Header'
+import { Box, Image, Container, Grid, Text } from 'theme-ui'
+import Footer from '@/components/Footer'
+import PreviewCard from '@/components/PreviewCard'
+import Link from 'next/link'
+
+/** @jsxImportSource theme-ui */
+export default function Index(props) {
+  const jams = props.jams || []
+
+  return (
+    <>
+      <Box
+        sx={{
+          backgroundImage:
+            'linear-gradient(180deg, #993CCF 0%, rgba(170, 77, 181, 0.95) 17.19%, rgba(193, 99, 146, 0.90) 31.77%, rgba(223, 129, 101, 0.71) 52.08%, rgba(240, 146, 75, 0.60) 63.54%, rgba(240, 146, 75, 0.00) 96.88%), linear-gradient(180deg, #D9D9D9 0%, rgba(255, 255, 255, 0.00) 100%)',
+          backgroundSize: 'cover',
+          color: 'white',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          pb: 6,
+          position: 'relative',
+          height: '100%'
+        }}>
+        <Box
+          sx={{
+            background:
+              'url(/assets/main-texture.svg), lightgray 0% 0% / 40.00000059604645px 40.00000059604645px repeat',
+            backgroundBlendMode: 'color-burn',
+            position: 'absolute',
+            top: 0,
+            left: '0',
+            zIndex: -1
+          }}
+        />
+        <Image
+          sx={{
+            width: '100%',
+            height: '100%',
+            position: 'absolute',
+            mixBlendMode: 'color-burn'
+          }}
+          src="https://cloud-omdlqtlig-hack-club-bot.vercel.app/0rectangle_60.png"
+        />
+
+        <Box
+          sx={{
+            p: 4,
+            textAlign: 'center',
+            marginTop: '64px',
+            position: 'relative',
+            zIndex: 2,
+            maxWidth: '760px'
+          }}>
+          <Text
+            as="h1"
+            sx={{
+              fontFamily: 'var(--heading)',
+              fontSize: [48, 56, 56],
+              textShadow: '0px 0px 64px 0px rgba(56, 10, 83, 0.75)',
+              mb: 0,
+              mt: 0,
+              lineHeight: 1,
+              fontWeight: 400
+            }}>
+            Community Guides
+          </Text>
+          <Box
+            sx={{
+              maxWidth: '48rem',
+              px: [2, 4],
+              py: [2, 3],
+              textAlign: 'center'
+            }}>
+            <Text
+              sx={{
+                textShadow: '0px 0px 32px 0px rgba(56, 10, 83, 0.50)',
+                fontSize: [16, 18, 22],
+                mt: 0,
+                lineHeight: 1.2,
+                pt: 0,
+                px: 3
+              }}>
+                These are guides spread across different events that Hack Club has run, and also created by fellow hackclubbers!
+            </Text>
+          </Box>
+          <Link href="/" style={{ color: 'white', fontSize: '1.3rem', fontWeight: '500' }}>
+            ← Head back to Jams
+          </Link>
+        </Box>
+      </Box>
+
+      <Container sx={{ marginTop: '-4rem', position: 'relative', zIndex: 1 }}>
+        <Box
+          sx={{
+            backgroundColor: '#FDF5EC',
+            border: '1px solid #F0924B',
+            padding: ['16px', '24px', '32px'],
+            borderRadius: '16px'
+          }}>
+          <Text
+            as="h2"
+            sx={{
+              fontSize: [24, 32, 42],
+              lineHeight: 1.2,
+              fontWeight: 600,
+              margin: 0,
+              p: 0,
+              zIndex: 2
+            }}>
+            New to Jams? Start Jamming!
+          </Text>
+          <Text
+            as="h2"
+            sx={{
+              fontSize: [18, 18, 24],
+              fontWeight: 400,
+              margin: 0,
+              p: 0,
+              zIndex: 2
+            }}>
+            Here's some of the most popular Jams created by Hack Clubbers.
+          </Text>
+          <Grid
+            columns={[null, '1fr', '1fr 1fr', '1fr 1fr 1fr', '1fr 1fr 1fr']}
+            gap={3}
+            sx={{ pt: 4, position: 'relative' }}>
+            {jams.map(jam => (
+              <PreviewCard key={jam.slug} {...jam} />
+            ))}
+          </Grid>
+        </Box>
+
+        <Text
+          as="h1"
+          sx={{
+            fontSize: 48,
+            fontWeight: 600,
+            mt: '2rem',
+            lineHeight: '3.5rem',
+            zIndex: 2,
+            display: 'flex',
+            gap: '1rem',
+            alignItems: 'first baseline'
+          }}>
+          Jams
+          <Link href="/guides" style={{ fontSize: '1.1rem', color: 'black' }}>
+            Want more? Check out the community guides →
+          </Link>
+        </Text>
+      </Container>
+
+      <Footer />
+    </>
+  )
+}

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -3,14 +3,58 @@ import { Box, Image, Container, Grid, Text } from 'theme-ui'
 import Footer from '@/components/Footer'
 import PreviewCard from '@/components/PreviewCard'
 import Link from 'next/link'
+import guides_data from '@/guides_data/data.json'
+import { useState, useEffect } from 'react'
+
 
 /** @jsxImportSource theme-ui */
 export default function Index(props) {
-  const jams = props.jams || []
+  const guides = guides_data;
+
+  const featuredGuidesList = ["Hackpad", "Riceathon", "RP2040 Devboard"]
+  const featuredGuides = guides.filter(guide =>
+    featuredGuidesList.includes(guide.Name)
+  );
+
+  const categories = ["Hardware", "CAD", "Web Development", "Game Development", "Command Line", "GitHub", "AI Tools", "Programming Languages"]
+  const [selectedCategories, setSelectedCategories] = useState([])
+  const [query, setQuery] = useState('')
+  const [filteredGuides, setFilteredGuides] = useState(guides);
+  const [difficulty, setDifficulty] = useState('')
+  const [time, setTime] = useState('')
+  const [viewed, setViewed] = useState([])
+
+  useEffect(() => {
+    const filtered = guides.filter((guide) => {
+      const matchesQuery = guide.Name
+        .toLowerCase()
+        .includes(query.toLowerCase());
+
+      const matchesCategories =
+        selectedCategories.length === 0 ||
+        selectedCategories.some((category) =>
+          guide.Keyword.includes(category)
+        );
+
+      const matchesDifficulty =
+        difficulty === "" || guide.Difficulty === difficulty.charAt(0).toUpperCase() + difficulty.slice(1);
+
+      const matchesTime =
+        time === "" || guide.TimeEstimate === time;
+
+      return matchesQuery && matchesCategories && matchesTime && matchesDifficulty;
+    });
+
+    setFilteredGuides(filtered);
+  }, [query, selectedCategories, difficulty, time]);
+
+  console.log(difficulty);
 
   return (
     <>
         <Header
+          query={query}
+          setQuery={setQuery}
           isHomePage={true}
         />
         <Box
@@ -129,12 +173,27 @@ export default function Index(props) {
             columns={[null, '1fr', '1fr 1fr', '1fr 1fr 1fr', '1fr 1fr 1fr']}
             gap={3}
             sx={{ pt: 4, position: 'relative' }}>
-            {jams.map(jam => (
-              <PreviewCard key={jam.slug} {...jam} />
+            {featuredGuides.map((guide, index) => (
+              <PreviewCard 
+                key={index} 
+                title={guide.Name}
+                thumbnail={guide.Image.includes("hc-cdn") ? 'http://cdn.hackclub.com/rescue?url=' + guide.Image : guide.Image}
+                redirect={guide.Link}
+                timeEstimate={guide.TimeEstimate}
+                keywords={guide.Keyword}
+                difficulty={guide.Difficulty}
+                isSortable={true}
+                isHot={true}
+                currentDifficulty={difficulty}
+                currentTime={time}
+                currentCategories={selectedCategories}
+                modifyDifficulty={setDifficulty}
+                modifyTime={setTime}
+                modifyCategories={setSelectedCategories}
+              />
             ))}
           </Grid>
         </Box>
-
         <Text
           as="h1"
           sx={{
@@ -142,10 +201,41 @@ export default function Index(props) {
             fontWeight: 600,
             mt: '2rem',
             lineHeight: '3.5rem',
-            zIndex: 2,
+            zIndex: 2
           }}>
           Guides 
         </Text>
+        <Text style={{ width: '100' }}>
+          {filteredGuides.length != 0 ? (
+            <p sx={{ m: 0 }}>{filteredGuides.length} Guides Found</p>
+          ) : (
+            <p sx={{ m: 0 }}>No Results Found</p>
+          )}
+        </Text>
+        <Grid
+          columns={[null, '1fr', '1fr 1fr', '1fr 1fr 1fr', '1fr 1fr 1fr']}
+          gap={3}
+          sx={{ pt: 3, pb: '4rem', mt: '1rem' }}>
+          {filteredGuides.map((guide, index) => (
+            <PreviewCard
+              key={index} 
+              title={guide.Name}
+              thumbnail={guide.Image.includes("hc-cdn") ? 'http://cdn.hackclub.com/rescue?url=' + guide.Image : guide.Image}
+              redirect={guide.Link}
+              timeEstimate={guide.TimeEstimate}
+              keywords={guide.Keyword}
+              difficulty={guide.Difficulty}
+              isSortable={true}
+              isHot={true}
+              currentDifficulty={difficulty}
+              currentTime={time}
+              currentCategories={selectedCategories}
+              modifyDifficulty={setDifficulty}
+              modifyTime={setTime}
+              modifyCategories={setSelectedCategories}
+            />
+          ))}
+        </Grid>
       </Container>
 
       <Footer />

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,7 @@ import PreviewCard from '@/components/PreviewCard'
 import { useEffect, useState, useRef } from 'react'
 import Icon from '@hackclub/icons'
 import { useRouter } from 'next/router'
+import Link from 'next/link'
 import lunr from 'lunr'
 
 import path from 'path'
@@ -708,7 +709,7 @@ export default function Index(props) {
             sx={{
               maxWidth: '48rem',
               px: [2, 4],
-              py: [2, 2],
+              py: [2, 3],
               textAlign: 'center'
             }}>
             <Text
@@ -724,6 +725,7 @@ export default function Index(props) {
               dissolve, and inventions come to life.
             </Text>
           </Box>
+          <Link href="/guides" style={{color: 'white', fontSize: '1.3rem', fontWeight: '500'}}>Check out the community guides too →</Link>
         </Box>
 
 {/*        <Slides initialFeatures={features} router={router} /> */}
@@ -1195,9 +1197,13 @@ export default function Index(props) {
             fontWeight: 600,
             mt: '2rem',
             lineHeight: '3.5rem',
-            zIndex: 2
+            zIndex: 2,
+            display: 'flex',
+            gap: '1rem',
+            alignItems: 'first baseline'
           }}>
           Jams
+          <Link href='/guides' style={{fontSize: '1.1rem', color: 'black'}}>Want more? Check out the community guides →</Link>
         </Text>
 
         <Text style={{ width: '100' }}>


### PR DESCRIPTION
Jams has been getting increasingly significant traffic with the introduction of the webOS tutorial into stardance and there's a lot of other amazing tutorials that I'm sure people would love to see so I've moved all the guides from other hackclub events onto it's own dedicated page on jams, and redirecting guides.hackclub.com to this new page.

TLDR:
- Adding new guides page
- Migrated all the guides data from guides.hackclub.com to this new page
- Migrated the guides.hackclub.com airtable to a JSON file so people can PR in their programs guides
- Fixed all the broken links, low quality guides, and images
- I ALSO MADE THE GRADIENT BLUE BECAUSE IT LOOKS SO PRETTY :DDD 

<img width="1914" height="993" alt="image" src="https://github.com/user-attachments/assets/ffe62a75-bbc1-495c-82b3-30a86d8f7476" />
