### PR TITLE
fixed the 3ed toutriol of webOs where there was a nameing collision i…

### DIFF
--- a/jams/batches/webOS/part-3/en-US.md
+++ b/jams/batches/webOS/part-3/en-US.md
@@ -165,11 +165,11 @@ function dragElement(element) {
     initialY = e.clientY;
     // Step 8: Set up event listeners for mouse movement (`elementDrag`) and mouse button release (`closeDragElement`).
     document.onmouseup = stopDragging;
-    document.onmousemove = dragElement;
+    document.onmousemove = elementDrag;
   }
 
   // Step 9: Define the `elementDrag` function to calculate the new position of the element based on mouse movement.
-  function dragElement(e) {
+  function elementDrag(e) {
     e = e || window.event;
     e.preventDefault();
     // Step 10: Calculate the new cursor position.


### PR DESCRIPTION
fix: resolve inner dragElement function naming collision :)
Fixed a function-shadowing bug where the inner movement handler function was named dragElement, sharing the exact name of the outer wrapper function. Renamed the inner function to elementDrag to match the inline comments and ensure clean variable scoping.