### PR TITLE
Point retired CDN asset URLs at /rescue (796 links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git push
 
 This will send the changes you made to your repository. To send it to ours, go to your repository on GitHub and click on the button that says `Contribute` right above the code viewer. It will ask you to `Open a pull request` - go ahead and do that. It'll take you to a page that looks like this:
 
-![PR page](https://cloud-3d1rlweqr-hack-club-bot.vercel.app/0screenshot_2023-08-16_at_15-47-10_comparing_hackclub_main...jianmin-chen_main____hackclub_workshops.png)
+![PR page](https://cdn.hackclub.com/rescue?url=https://cloud-3d1rlweqr-hack-club-bot.vercel.app/0screenshot_2023-08-16_at_15-47-10_comparing_hackclub_main...jianmin-chen_main____hackclub_workshops.png)
 
 Fill in the title, maybe add a little description, and click that big green button that says `Create pull request`! That's it! You've made a PR!
 
@@ -73,7 +73,7 @@ isBatch: True
 
 We use this info for this page:
 
-![Batch info](https://cloud-qitwm6rk9-hack-club-bot.vercel.app/0screenshot_2023-08-16_at_14-45-22_create_your_own_smart_ai_voice_companion.png)
+![Batch info](https://cdn.hackclub.com/rescue?url=https://cloud-qitwm6rk9-hack-club-bot.vercel.app/0screenshot_2023-08-16_at_14-45-22_create_your_own_smart_ai_voice_companion.png)
 
 Now you can start writing the parts for your jam! For every part of your jam, create a folder inside your jam folder titled `part-<part #>`. Create a file inside that folder called `en-US.md` (or whatever your locale is) and will it with the following content:
 

--- a/guides_data/data.json
+++ b/guides_data/data.json
@@ -1,7 +1,7 @@
 [
   {
     "Name": "Build Your Own Custom Mouse",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/303d6f71d20b857c40991b5a4a0a9e8a51d7982e_tut_0.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/303d6f71d20b857c40991b5a4a0a9e8a51d7982e_tut_0.png",
     "Link": "https://blueprint.hackclub.com/starter-projects/squeak",
     "Keyword": "CAD",
     "Difficulty": "Beginner",
@@ -9,7 +9,7 @@
   },
   {
     "Name": "Learn Backend Programming in ExpressJS",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/046cbfcd93eaf65aea3ff570cedf4def19c7bd53_Screenshot_2025-12-09_at_3.37.59_PM.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/046cbfcd93eaf65aea3ff570cedf4def19c7bd53_Screenshot_2025-12-09_at_3.37.59_PM.png",
     "Link": "https://express.athena.hackclub.com/home",
     "Keyword": "Web Development",
     "Difficulty": "Intermediate",
@@ -26,7 +26,7 @@
   },
   {
     "Name": "Program Your Own Personal Site",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/9f630a1f173d441d3300a41ffd97a2459cb69ff4_Screenshot_2025-12-10_at_1.32.21_PM.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/9f630a1f173d441d3300a41ffd97a2459cb69ff4_Screenshot_2025-12-10_at_1.32.21_PM.png",
     "Link": "https://workshops.hackclub.com/personal_website/",
     "Keyword": "Web Development",
     "Difficulty": "Beginner",
@@ -34,7 +34,7 @@
   },
   {
     "Name": "Create Your Own eFidget",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/6fb37d980f8c75f6ea7283e98df3ba092de72a5b_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/6fb37d980f8c75f6ea7283e98df3ba092de72a5b_image.png",
     "Link": "https://pathfinder.hackclub.com/",
     "Keyword": "Hardware",
     "Difficulty": "Intermediate",
@@ -42,7 +42,7 @@
   },
   {
     "Name": "Design Your First PCB With a Sensor",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/96455b23db3ab2b41028d98aec5800b80037ef6f_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/96455b23db3ab2b41028d98aec5800b80037ef6f_image.png",
     "Link": "https://hermes.hackclub.com/",
     "Keyword": "Hardware",
     "Difficulty": "Intermediate",
@@ -50,7 +50,7 @@
   },
   {
     "Name": "Make Your Own Music Visualizer",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/462777ca0390496fc3a0f61c38f5686c6f6f1acc_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/462777ca0390496fc3a0f61c38f5686c6f6f1acc_image.png",
     "Link": "https://waveform.hackclub.com/tutorial",
     "Keyword": "Web Development",
     "Difficulty": "Beginner",
@@ -58,7 +58,7 @@
   },
   {
     "Name": "Learn to Make Pull Requests",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/98803600c0d04dc2_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/98803600c0d04dc2_image.png",
     "Link": "https://draw-dino.hackclub.com/",
     "Keyword": "GitHub",
     "Difficulty": "Beginner",
@@ -66,7 +66,7 @@
   },
   {
     "Name": "Make Your Own Macropad",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/6b9c8661f5ae68437e90d14a214f899759eb30b5_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/6b9c8661f5ae68437e90d14a214f899759eb30b5_image.png",
     "Link": "https://blueprint.hackclub.com/hackpad",
     "Keyword": "Hardware",
     "Difficulty": "Beginner",
@@ -74,7 +74,7 @@
   },
   {
     "Name": "Learn to Use Hack Club AI",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/95fe506b80a8873c_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/95fe506b80a8873c_image.png",
     "Link": "https://docs.ai.hackclub.com/",
     "Keyword": "AI Tools",
     "Difficulty": "Beginner",
@@ -82,7 +82,7 @@
   },
   {
     "Name": "Code Your First Site and Get Boba",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/17234390cb3b74c4_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/17234390cb3b74c4_image.png",
     "Link": "https://www.canva.com/design/DAGr1zQLfE4/eqe5sSP6hE9-4SZez72QFA/view?utm_content=DAGr1zQLfE4&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h25bb5bce98",
     "Keyword": "Web Development",
     "Difficulty": "Beginner",
@@ -98,7 +98,7 @@
   },
   {
     "Name": "Learn to Make Beautiful READMEs",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/aa0e5b70d3b6444d_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/aa0e5b70d3b6444d_image.png",
     "Link": "https://highway.hackclub.com/guides/beautiful-readmes",
     "Keyword": "Hardware",
     "Difficulty": "Beginner",
@@ -106,7 +106,7 @@
   },
   {
     "Name": "Design Custom Keycaps",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/558ce7c0a4677fe6_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/558ce7c0a4677fe6_image.png",
     "Link": "https://highway.hackclub.com/guides/custom-keycaps",
     "Keyword": "CAD",
     "Difficulty": "Intermediate",
@@ -114,7 +114,7 @@
   },
   {
     "Name": "Riceathon - Customize Your Own Linux Desktop",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/b4bf96a3ecfbe5c1_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/b4bf96a3ecfbe5c1_image.png",
     "Link": "https://riceathon.hackclub.com/better-guide/guide.html",
     "Keyword": "Command Line",
     "Difficulty": "Advanced",
@@ -122,7 +122,7 @@
   },
   {
     "Name": "The Zoo SvelteKit Guide",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/0bc04a1846b26ed9_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/0bc04a1846b26ed9_image.png",
     "Link": "https://github.com/hackclub/The-Zoo/blob/main/zoo.pdf",
     "Keyword": "Web Development",
     "Difficulty": "Intermediate",
@@ -130,7 +130,7 @@
   },
   {
     "Name": "Create Your Own Split Keyboard",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/e2caab7c07431f23_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/e2caab7c07431f23_image.png",
     "Link": "https://blueprint.hackclub.com/starter-projects/split-keyboard",
     "Keyword": "Hardware",
     "Difficulty": "Intermediate",
@@ -138,7 +138,7 @@
   },
   {
     "Name": "Design a Flight Controller PCB",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/94d237c4d7e48eb2_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/94d237c4d7e48eb2_image.png",
     "Link": "https://blueprint.hackclub.com/starter-projects/flightcontroller",
     "Keyword": "Hardware",
     "Difficulty": "Advanced",
@@ -146,7 +146,7 @@
   },
   {
     "Name": "Make Your Own Midi Keyboard",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/710054274784eca36dca4ca7a384e5b2f1fd4c9c_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/710054274784eca36dca4ca7a384e5b2f1fd4c9c_image.png",
     "Link": "https://blueprint.hackclub.com/starter-projects/midi",
     "Keyword": "Hardware",
     "Difficulty": "Intermediate",
@@ -154,7 +154,7 @@
   },
   {
     "Name": "Learn the Basics of KiCad & PCB Design",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/ad0f0ce4430583c1_image.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/ad0f0ce4430583c1_image.png",
     "Link": "https://solder.hackclub.com/start",
     "Keyword": "Hardware",
     "Difficulty": "Beginner",
@@ -162,7 +162,7 @@
   },
   {
     "Name": "Make a Blinky Board",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/766c5aee15a8c57b1bd57467f3382fc68c0a627c_unnamed.gif",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/766c5aee15a8c57b1bd57467f3382fc68c0a627c_unnamed.gif",
     "Link": "https://blueprint.hackclub.com/starter-projects/blinky",
     "Keyword": "Hardware",
     "Difficulty": "Beginner",
@@ -170,7 +170,7 @@
   },
   {
     "Name": "Create Your Own Programming Language",
-    "Image": "https://hc-cdn.hel1.your-objectstorage.com/s/v3/f0ace900ea47c5ad_screenshot_20251213_173454.png",
+    "Image": "https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/f0ace900ea47c5ad_screenshot_20251213_173454.png",
     "Link": "https://easel.hackclub.com/orpheus-finds-easel",
     "Keyword": "Programming Languages",
     "Difficulty": "Advanced",

--- a/jams/batches/3d-armory/part-1/en-US.md
+++ b/jams/batches/3d-armory/part-1/en-US.md
@@ -5,14 +5,14 @@ batch: '3d-armory'
 description: >  
   In this Jam, you'll be learning what CAD is, the functions of TinkerCAD, and learning how to make the blade of a medieval sword. You will have fun customizing your blade while learning both how to use TinkerCAD AND how to think like a 3D Modeler! 
 contributor: 'thesuperRL'  
-thumbnail: 'https://cloud-ft14x3slq-hack-club-bot.vercel.app/0image.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-ft14x3slq-hack-club-bot.vercel.app/0image.png'
 timeEstimate: '40 Min'  
 difficulty: 'Beginner'
 keywords: 'Sword, CAD, 3D Design, Model, TinkerCAD, 3D Printing, 3D, 3d'  
 language: 'N/A'
 presentation: "https://www.figma.com/file/382ID03pU0oFQhYQRHc86V/Forge-of-Legends-Part-1-Presentation?type=design&node-id=0-1&mode=design&t=5cqrU8dmRL9Ap3a0-0" 
 presentationPlay: "https://www.figma.com/proto/382ID03pU0oFQhYQRHc86V/Forge-of-Legends-Part-1-Presentation?type=design&node-id=1-3&t=PAhbnoBq1Sn0zbae-0&scaling=contain&page-id=0%3A1" 
-presentationPDF: "https://cloud-a4eaqfm9v-hack-club-bot.vercel.app/0forge_of_legends_part_1_presentation__2_.pdf" 
+presentationPDF: "https://cdn.hackclub.com/rescue?url=https://cloud-a4eaqfm9v-hack-club-bot.vercel.app/0forge_of_legends_part_1_presentation__2_.pdf" 
 notes: "https://docs.google.com/document/d/1MsnPHKdCjI5Qz-b-30BlTOcyaVMjJLMo8Am--FTmLgA/edit" 
 poster: "" 
 video: "" 
@@ -21,7 +21,7 @@ contributorSlackID: "U05E2FK240N"
 ---
 
 
-![Fire](https://cloud-bwybtmgkd-hack-club-bot.vercel.app/0image.png)
+![Fire](https://cdn.hackclub.com/rescue?url=https://cloud-bwybtmgkd-hack-club-bot.vercel.app/0image.png)
 
 (3D Modeled fire credits to Thiên Huỳnh Quốc)
 
@@ -58,7 +58,7 @@ CAD can be split into two major types: 2D CAD and 3D CAD.
 
 ##### 2D CAD
 
-![A 2D CAD Floor Plan](https://cloud-b9hkk1e7s-hack-club-bot.vercel.app/0image.png)
+![A 2D CAD Floor Plan](https://cdn.hackclub.com/rescue?url=https://cloud-b9hkk1e7s-hack-club-bot.vercel.app/0image.png)
 
 (Barki, Hichem & Fadli, Fodil & Shaat, Ahmed & Boguslawski, Pawel & Mahdjoubi, Lamine. (2015). BIM Models Generation From 2D CAD Drawings And 3D Scans: An Analysis Of Challenges And Opportunities For AEC Practitioners. 10.2495/BIM150311.)
 
@@ -66,7 +66,7 @@ CAD can be split into two major types: 2D CAD and 3D CAD.
 
 ##### 3D CAD
 
-![3D CAD Manufacturing Part](https://cloud-2ciz1c7b0-hack-club-bot.vercel.app/0image.png)
+![3D CAD Manufacturing Part](https://cdn.hackclub.com/rescue?url=https://cloud-2ciz1c7b0-hack-club-bot.vercel.app/0image.png)
 
 (Osborne, Angela, 6-21-2022, "Autodesk Fusion 360 Unifies Design, Manufacturing Process," Production Machining, https://www.productionmachining.com/products/autodesk-fusion-360-unifies-design-manufacturing-process)
 
@@ -74,7 +74,7 @@ CAD can be split into two major types: 2D CAD and 3D CAD.
 
 ##### CAD in Industry
 
-![Some Industry Uses](https://cloud-2iy9idjv7-hack-club-bot.vercel.app/0image.png)
+![Some Industry Uses](https://cdn.hackclub.com/rescue?url=https://cloud-2iy9idjv7-hack-club-bot.vercel.app/0image.png)
 
 (Michael Gigante, 7-15-2020, "Computer-Aided Design (CAD): State of Category," G2, https://www.g2.com/articles/computer-aided-design-cad-state-of-category)
 ^ Provides a lot of cool insights about uses of CAD in the Market today
@@ -148,7 +148,7 @@ I found many very interesting communities on discord. All of them are filled wit
 
 Welcome to your TinkerCAD Dashboard! 
 
-![TinkerCAD Home](https://cloud-9lm6dohxy-hack-club-bot.vercel.app/0image.png)
+![TinkerCAD Home](https://cdn.hackclub.com/rescue?url=https://cloud-9lm6dohxy-hack-club-bot.vercel.app/0image.png)
 
 On the left is your profile. Everything here is self explanatory, and Collections is equivalent to folders (or I guess something like an armory to store collections of items). 
 
@@ -162,13 +162,13 @@ At the middle-top of the screen you can find many different things. From left to
 
 If you scroll down a bit, you can find the three types of things that TinkerCAD currently allows you to make. 
 
-![Scrolled Down](https://cloud-3y9wqx163-hack-club-bot.vercel.app/0image.png)
+![Scrolled Down](https://cdn.hackclub.com/rescue?url=https://cloud-3y9wqx163-hack-club-bot.vercel.app/0image.png)
 
 We'll start with the first one, a 3D design. Create a new one, and let's hop in!
 
 ## Learning the Ways of the Craft
 
-![BP](https://cloud-r7su62mp4-hack-club-bot.vercel.app/0image.png)
+![BP](https://cdn.hackclub.com/rescue?url=https://cloud-r7su62mp4-hack-club-bot.vercel.app/0image.png)
 
 Woah...
 
@@ -180,7 +180,7 @@ Did you expect this forge to be realistic, and accurate to the Middle Ages?
 
 NO! Like many fantasy worlds, we have ***MAGIC*** to speed up your forging process!
 
-![Magic](https://cloud-6r1vkcvp3-hack-club-bot.vercel.app/0image.png)
+![Magic](https://cdn.hackclub.com/rescue?url=https://cloud-6r1vkcvp3-hack-club-bot.vercel.app/0image.png)
 
 These are your magical tools that do the basic functions for you.
 
@@ -203,7 +203,7 @@ If you're using the spellbook Mac Book, just use Cmd instead.
 
 ### Top Right: Magic Simulations
 
-![Sims](https://cloud-fknezgu6z-hack-club-bot.vercel.app/0image.png)
+![Sims](https://cdn.hackclub.com/rescue?url=https://cloud-fknezgu6z-hack-club-bot.vercel.app/0image.png)
 
 From left to right, they are:
 
@@ -215,7 +215,7 @@ Invite Collaborators
 
 ### Just Below That: Taking it out of the Forge
 
-![Exporting](https://cloud-iap0mf39z-hack-club-bot.vercel.app/0image.png)
+![Exporting](https://cdn.hackclub.com/rescue?url=https://cloud-iap0mf39z-hack-club-bot.vercel.app/0image.png)
 
 First, the blue buttons below let you create workplanes, rulers, and notes. 
 
@@ -225,7 +225,7 @@ Below this is the gallery of shapes, and to the right are additional tools. We w
 
 ### The Workplane: Your Anvil
 
-![Workplane](https://cloud-1a8ccnyrn-hack-club-bot.vercel.app/0image.png)
+![Workplane](https://cdn.hackclub.com/rescue?url=https://cloud-1a8ccnyrn-hack-club-bot.vercel.app/0image.png)
 
 Finally we get to the biggest thing on the screen. This is where all of your items are going to go. 
 
@@ -251,13 +251,13 @@ TinkerCAD's assistants already made the base materials for our sword, so that yo
 
 Remember the shapes panel to the very right? Now we are going to introduce that. 
 
-![Sidebar](https://cloud-guk4phez0-hack-club-bot.vercel.app/0image.png)
+![Sidebar](https://cdn.hackclub.com/rescue?url=https://cloud-guk4phez0-hack-club-bot.vercel.app/0image.png)
 
 This side panel shows you all the shapes for your project. These basic shapes let you create the basic parts of your model from common polyhedrons, and there are many shapes that others have made already, which you can find by expanding the drop-down bar and clicking on another collection.
 
 Alright, now let's place a cube into the workspace. Drag the red cube onto the workplane (or just click twice). A small menu should pop up: 
 
-![ObjMenu](https://cloud-uelpmjkk4-hack-club-bot.vercel.app/0image.png)
+![ObjMenu](https://cdn.hackclub.com/rescue?url=https://cloud-uelpmjkk4-hack-club-bot.vercel.app/0image.png)
 
 These are the shape's **Attributes**. Each shape has its own unique attributes, but generally all shapes have at least one. 
 
@@ -271,13 +271,13 @@ We will address what Solid and Hole means in part 2! We will explore that in par
 
 As a 3D Modeler (or Blacksmith, however you prefer to call yourself), you need to practice the skill of generalizing an object into its basic, regular polyhedron pieces. Or in other words, you have to break an object up into its basic shapes (if you are an artist, it's like breaking an animal's leg into quadrilaterals for easier drawing).
 
-![bird](https://cloud-lo854k5el-hack-club-bot.vercel.app/0image.png)
+![bird](https://cdn.hackclub.com/rescue?url=https://cloud-lo854k5el-hack-club-bot.vercel.app/0image.png)
 
 (Administrator, 12-6-2020, "Week Starting 7th December," Space Aylesbury, https://www.spaceaylesbury.org/week-starting-7th-december-breaking-down-a-drawing-into-shapes-part-1/)
 
 We will practice this on the blade. Let's look at how a sword's blade usually looks (along with my terrible drawing).
 
-![Sword Breakdown](https://cloud-2a8js3e0d-hack-club-bot.vercel.app/0screenshot_2023-08-03_at_1.54.34_pm.png)
+![Sword Breakdown](https://cdn.hackclub.com/rescue?url=https://cloud-2a8js3e0d-hack-club-bot.vercel.app/0screenshot_2023-08-03_at_1.54.34_pm.png)
 
 (Militarysurplusworld.Com Based On Idosell, n.d., "Ferrum sword -Magnum," militarysurplusworld, https://www.militarysurplusworld.com/product-eng-43263-Ferrum-sword-Magnum.html)
 
@@ -285,7 +285,7 @@ Looks like a long, almost rectangular shape, with a triangle attached to the end
 
 And let's also look at the cross-section. 
 
-![Blade Cross Sections](https://cloud-ffm4mev78-hack-club-bot.vercel.app/0image.png)
+![Blade Cross Sections](https://cdn.hackclub.com/rescue?url=https://cloud-ffm4mev78-hack-club-bot.vercel.app/0image.png)
 
 (Starr Z. Davies, n.d., "Wednesday Warriors," https://starrzdavies.com/wednesday-warriors-3-basic-blade-cross-sections-and-their-purpose/)
 
@@ -325,13 +325,13 @@ Let me tell you the ways of the 3D Modeling Blacksmith. There's 3 ways to make a
 
 Let's take a look at the sidebar again, and cross out everything that doesn't look even remotely workable. We need sharp edges, right? We can cross out all the rounded shapes.
 
-![Crossed out bad options](https://cloud-d7x8mzz7m-hack-club-bot.vercel.app/0image.png)
+![Crossed out bad options](https://cdn.hackclub.com/rescue?url=https://cloud-d7x8mzz7m-hack-club-bot.vercel.app/0image.png)
 
 Let's go through our options and try each one. First is addition. We know that we want a rhombus shape, and a rhombus is basically just two triangles. The green triangular prism seems up to the job. Let's drag it onto the workplane.
 
 Oh right, let me tell you the basic controls. Click to select, Hold right click and drag to change perspective, and scroll to zoom. Press shift while dragging with right click to slide your perspective. If you want to return to a cardinal direction, just click a face, edge, or vertex of the little cube at the top left.
 
-![Selecting a Shape](https://cloud-ekuqoiqkx-hack-club-bot.vercel.app/0image.png)
+![Selecting a Shape](https://cdn.hackclub.com/rescue?url=https://cloud-ekuqoiqkx-hack-club-bot.vercel.app/0image.png)
 
 The blue highlight shows what you are clicking, the white squares at the bottom allow you to modify the length and width when you drag it, and the black dots only change one dimension if you want to (for instance) lock the width and only modify the length. The top white dot also lets you only modify the height.
 
@@ -341,39 +341,39 @@ The three arrow things indicate rotations. We will be using that now.
 
 We want to rotate this so it stands upright. Click and hole on the little rotation button you see on the top right (you may want to change perspectives, since if you are just looking at the front you won't see it)
 
-![Rotation Ring](https://cloud-kyclafb1o-hack-club-bot.vercel.app/0image.png)
+![Rotation Ring](https://cdn.hackclub.com/rescue?url=https://cloud-kyclafb1o-hack-club-bot.vercel.app/0image.png)
 
 Now a ring will pop up. Drag it around the ring, but hold it over the bigger inside ticks instead of the smaller outside ticks. Doing this makes your shape snap to 45 degree increments instead of making it less precise.
 
-![Rotated](https://cloud-7m6d0lwtj-hack-club-bot.vercel.app/0image.png)
+![Rotated](https://cdn.hackclub.com/rescue?url=https://cloud-7m6d0lwtj-hack-club-bot.vercel.app/0image.png)
 
 Great! It's upright! We'll need another prism, so just go ahead and make another one, but rotate it the other way. You can also drag the shape to move it around
 
 Now let's align and merge.
 
-![Two aligned](https://cloud-68ym5um4a-hack-club-bot.vercel.app/0image.png)
+![Two aligned](https://cdn.hackclub.com/rescue?url=https://cloud-68ym5um4a-hack-club-bot.vercel.app/0image.png)
 
 Move it until it's roughly touching. The line between them will be very thin.
 
-![Two Touching](https://cloud-k5j0yfozs-hack-club-bot.vercel.app/0image.png)
+![Two Touching](https://cdn.hackclub.com/rescue?url=https://cloud-k5j0yfozs-hack-club-bot.vercel.app/0image.png)
 
 Next, hold shift and select both shapes. Look to the top right, the group symbol should light up.
 
-![Group Button](https://cloud-fb1jdb1yr-hack-club-bot.vercel.app/0image.png)
+![Group Button](https://cdn.hackclub.com/rescue?url=https://cloud-fb1jdb1yr-hack-club-bot.vercel.app/0image.png)
 
-![Selected](https://cloud-q9pyttv6b-hack-club-bot.vercel.app/0image.png)
+![Selected](https://cdn.hackclub.com/rescue?url=https://cloud-q9pyttv6b-hack-club-bot.vercel.app/0image.png)
 
 Click it and after a while, the line between should dissapear. You've grouped a shape! 
 
-![Merged](https://cloud-7o9iz07ko-hack-club-bot.vercel.app/0image.png)
+![Merged](https://cdn.hackclub.com/rescue?url=https://cloud-7o9iz07ko-hack-club-bot.vercel.app/0image.png)
 
 Now just stretch it a bit with the little black dot at the bottom.
 
-![Selected Bottom Dot](https://cloud-1zlkxugpq-hack-club-bot.vercel.app/0image.png)
+![Selected Bottom Dot](https://cdn.hackclub.com/rescue?url=https://cloud-1zlkxugpq-hack-club-bot.vercel.app/0image.png)
 
 The number indicates now long in millimeters it is. Click and type into it to indicate a length if you would like, or just drag the black dot that should have just turned red. 
 
-![Stretched](https://cloud-adhbzxjbq-hack-club-bot.vercel.app/0image.png)
+![Stretched](https://cdn.hackclub.com/rescue?url=https://cloud-adhbzxjbq-hack-club-bot.vercel.app/0image.png)
 
 Great! That's one way of forging the stem. The other way, using the modification technique, will be left as an exercise to the reader (always wanted to say that)
 
@@ -395,7 +395,7 @@ Now, just drag the top white dot upwards, and you now have a long blade! For now
 
 Remember the dimensions of the bottom? Just click on a white dot to check.
 
-![Check Dimensions](https://cloud-ozsdfln1l-hack-club-bot.vercel.app/0image.png)
+![Check Dimensions](https://cdn.hackclub.com/rescue?url=https://cloud-ozsdfln1l-hack-club-bot.vercel.app/0image.png)
 
 20 mm by 50 mm. Let's now make the tip. Let's also go a bit faster now that you've learn the basics. 
 
@@ -403,43 +403,43 @@ Drag a yellow pyramid onto the plane, and rotate it 45 degrees to align with the
 
 Edit its dimensions to match with the base. 
 
-![Sword Tip](https://cloud-22l1svwby-hack-club-bot.vercel.app/0image.png)
+![Sword Tip](https://cdn.hackclub.com/rescue?url=https://cloud-22l1svwby-hack-club-bot.vercel.app/0image.png)
 
 Let's use a neat little tool called align. select both shapes with shift, now click this new button on the top right.
 
-![Align Button](https://cloud-22l1svwby-hack-club-bot.vercel.app/1image.png)
+![Align Button](https://cdn.hackclub.com/rescue?url=https://cloud-22l1svwby-hack-club-bot.vercel.app/1image.png)
 
 Black dots should pop up. Each one aligns the shapes in a different dimension. We are interested in the ones in the middle of the base. 
 
-![Align Dots](https://cloud-m5wixe5jx-hack-club-bot.vercel.app/0image.png)
+![Align Dots](https://cdn.hackclub.com/rescue?url=https://cloud-m5wixe5jx-hack-club-bot.vercel.app/0image.png)
 
 You should get this. 
 
-![Inside](https://cloud-m5wixe5jx-hack-club-bot.vercel.app/1image.png)
+![Inside](https://cdn.hackclub.com/rescue?url=https://cloud-m5wixe5jx-hack-club-bot.vercel.app/1image.png)
 
 Press "d" to situate it on the workplane, and drag the pyramid up using the arrow until it aligns with the base, much like we did earlier with the two green triangles.
 
-![Aligned Vertically](https://cloud-m5wixe5jx-hack-club-bot.vercel.app/2image.png)
+![Aligned Vertically](https://cdn.hackclub.com/rescue?url=https://cloud-m5wixe5jx-hack-club-bot.vercel.app/2image.png)
 
 Group them together, and you have a short blade!
 
-![Short Blade](https://cloud-m5wixe5jx-hack-club-bot.vercel.app/3image.png)
+![Short Blade](https://cdn.hackclub.com/rescue?url=https://cloud-m5wixe5jx-hack-club-bot.vercel.app/3image.png)
 
 Don't worry if it changed entirely to yellow or green, TinkerCAD assigns colors based on its parts to the grouped whole. just click on it, and then this in the sidebar to change color if you would like. 
 
-![Item Color](https://cloud-m5wixe5jx-hack-club-bot.vercel.app/4image.png)
+![Item Color](https://cdn.hackclub.com/rescue?url=https://cloud-m5wixe5jx-hack-club-bot.vercel.app/4image.png)
 
 To lengthen the blade, let's drag the top white dot upwards, but not before zooming out first so we have more space. 
 
-![Top Dot Drag](https://cloud-m5wixe5jx-hack-club-bot.vercel.app/5image.png)
+![Top Dot Drag](https://cdn.hackclub.com/rescue?url=https://cloud-m5wixe5jx-hack-club-bot.vercel.app/5image.png)
 
 Feel free to click this button and ungroup to resize the stem and tip individually. 
 
-![Ungroup](https://cloud-m5wixe5jx-hack-club-bot.vercel.app/6image.png)
+![Ungroup](https://cdn.hackclub.com/rescue?url=https://cloud-m5wixe5jx-hack-club-bot.vercel.app/6image.png)
 
 Great! You now have a blade of the legends!!!
 
-![End Blade](https://cloud-m5wixe5jx-hack-club-bot.vercel.app/7image.png)
+![End Blade](https://cdn.hackclub.com/rescue?url=https://cloud-m5wixe5jx-hack-club-bot.vercel.app/7image.png)
 
 
 

--- a/jams/batches/3d-armory/part-2/en-US.md
+++ b/jams/batches/3d-armory/part-2/en-US.md
@@ -5,14 +5,14 @@ batch: '3d-armory'
 description: >  
     In this Jam, you will be finishing the hilt of the sword that we made in the last jam part. You will have fun customizing your product while learning both how to use TinkerCAD AND how to think like a 3D Modeler! 
 contributor: 'thesuperRL'  
-thumbnail: 'https://cloud-ft14x3slq-hack-club-bot.vercel.app/1image.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-ft14x3slq-hack-club-bot.vercel.app/1image.png'
 timeEstimate: '30 Min'  
 difficulty: 'Beginner'
 keywords: 'Sword, CAD, 3D Design, Model, TinkerCAD, 3D Printing, 3D, 3d'  
 language: 'N/A'
 presentation: "https://www.figma.com/file/tjUONBV4t7nCGpdYqXHfe0/Forge-of-Legends-Part-2-Presentation?type=design&node-id=0%3A1&mode=design&t=Rj7r7AQCUkpHkSFB-1" 
 presentationPlay: "https://www.figma.com/proto/tjUONBV4t7nCGpdYqXHfe0/Forge-of-Legends-Part-2-Presentation?type=design&node-id=2-14&t=PAhbnoBq1Sn0zbae-0&scaling=contain&page-id=0%3A1" 
-presentationPDF: "https://cloud-ec18cvc7z-hack-club-bot.vercel.app/0forge_of_legends_part_2_presentation__1_.pdf" 
+presentationPDF: "https://cdn.hackclub.com/rescue?url=https://cloud-ec18cvc7z-hack-club-bot.vercel.app/0forge_of_legends_part_2_presentation__1_.pdf" 
 notes: "https://docs.google.com/document/d/1MsnPHKdCjI5Qz-b-30BlTOcyaVMjJLMo8Am--FTmLgA/edit" 
 poster: ""
 video: "" 
@@ -20,11 +20,11 @@ totalParts: 2
 contributorSlackID: "U05E2FK240N"
 ---
 
-![Excalibur?](https://cloud-jtvxpzl1c-hack-club-bot.vercel.app/0image.png)
+![Excalibur?](https://cdn.hackclub.com/rescue?url=https://cloud-jtvxpzl1c-hack-club-bot.vercel.app/0image.png)
 
 *(Mountains and crystal models from TinkerCAD's Library)*
 
-![woscenery](https://cloud-jtvxpzl1c-hack-club-bot.vercel.app/1image.png)
+![woscenery](https://cdn.hackclub.com/rescue?url=https://cloud-jtvxpzl1c-hack-club-bot.vercel.app/1image.png)
 
 *(and now without scenery)*
 
@@ -48,7 +48,7 @@ Remember to use the handout from last time!
 
 Let's do a similar process with 
 
-![Wikipedia Image of Sword Parts](https://cloud-jtvxpzl1c-hack-club-bot.vercel.app/2image.png)
+![Wikipedia Image of Sword Parts](https://cdn.hackclub.com/rescue?url=https://cloud-jtvxpzl1c-hack-club-bot.vercel.app/2image.png)
 
 When you are modeling (like when you are programming), it's always helpful to break big items into smaller parts. Modeling individual pieces and grouping them together is always easier than trying to do the whole thing. 
 
@@ -71,7 +71,7 @@ Let's take a look at a real one
 
 It looks already quite simple, but we can make it simpler. It's basically the same as the blade (a diamond prism shape) but stretched way wider and being shorter.
 
-![Hilt Base](https://cloud-lpi8legia-hack-club-bot.vercel.app/0image.png)
+![Hilt Base](https://cdn.hackclub.com/rescue?url=https://cloud-lpi8legia-hack-club-bot.vercel.app/0image.png)
 
 If you wanted a straight handguard, we are done. But we can do better than that. 
 
@@ -85,33 +85,33 @@ In this case, let's try subtraction since it's hard to add a curve or do anythin
 
 Let's grab a cylinder and rotate it 90 degrees. Stretch it out lengthwise and decrease its height to make its curve more gradual. 
 
-![Cylinder Modifying](https://cloud-lpi8legia-hack-club-bot.vercel.app/1image.png)
+![Cylinder Modifying](https://cdn.hackclub.com/rescue?url=https://cloud-lpi8legia-hack-club-bot.vercel.app/1image.png)
 
 Let's duplicate it (either by using Ctrl C and Ctrl V, or just Ctrl D). Move it so that they are barely touching, and use our old friend the align tool to, well, align them. 
 
-![Align](https://cloud-lpi8legia-hack-club-bot.vercel.app/2image.png)
+![Align](https://cdn.hackclub.com/rescue?url=https://cloud-lpi8legia-hack-club-bot.vercel.app/2image.png)
 
 Notice how I will only click the red dot (align width-wise) and not the middle dot on the long side, since that will just make them overlap. We get this:
 
-![Cyl2](https://cloud-lpi8legia-hack-club-bot.vercel.app/3image.png)
+![Cyl2](https://cdn.hackclub.com/rescue?url=https://cloud-lpi8legia-hack-club-bot.vercel.app/3image.png)
 
 Group them, and align them with the red hilt body. You can make a few adjustments to the height and length of the cylinder abomination, and make sure to move it up a bit since we want to cut the top, not the bottom of the red shape.
 
-![Example](https://cloud-lpi8legia-hack-club-bot.vercel.app/4image.png)
+![Example](https://cdn.hackclub.com/rescue?url=https://cloud-lpi8legia-hack-club-bot.vercel.app/4image.png)
 
 Now we address what you see here: Holes. 
 
-![Holes](https://cloud-lpi8legia-hack-club-bot.vercel.app/5image.png)
+![Holes](https://cdn.hackclub.com/rescue?url=https://cloud-lpi8legia-hack-club-bot.vercel.app/5image.png)
 
 You're probably wondering how we can do subtraction, if so far all I showed you is combining two shapes into one. To that I say, we use **holes**. 
 
 Grouping a hole with a solid cuts holes in it. Let's make the orange shape a hole, and then use the group tool on it and the red shape. 
 
 Before the grouping:
-![pregroup](https://cloud-lpi8legia-hack-club-bot.vercel.app/6image.png)
+![pregroup](https://cdn.hackclub.com/rescue?url=https://cloud-lpi8legia-hack-club-bot.vercel.app/6image.png)
 
 After the grouping:
-![postgroup](https://cloud-lpi8legia-hack-club-bot.vercel.app/7image.png)
+![postgroup](https://cdn.hackclub.com/rescue?url=https://cloud-lpi8legia-hack-club-bot.vercel.app/7image.png)
 
 A small tip with holes: remember that you can use an object you've already cut shapes out of as another hole! 
 
@@ -121,7 +121,7 @@ A small tip with holes: remember that you can use an object you've already cut s
 
 With this technique I made the bottom curve as well. Try to figure out how I did that as a challenge, or simply move on if you'd like. 
 
-![chal](https://cloud-lpi8legia-hack-club-bot.vercel.app/8image.png)
+![chal](https://cdn.hackclub.com/rescue?url=https://cloud-lpi8legia-hack-club-bot.vercel.app/8image.png)
 
 Great! You've made it past the most difficult part! You can stay here to decorate more, but for our purposes (whether you did the challenge or not) this hilt is more than enough. Now let's move on. 
 
@@ -133,15 +133,15 @@ This is much easier. All we need is a cylinder that shrinks as you get higher. I
 
 If you search up frustum you will probably see diagrams like this:
 
-![Cone Frustum](https://cloud-fb5vv4641-hack-club-bot.vercel.app/0image.png)
+![Cone Frustum](https://cdn.hackclub.com/rescue?url=https://cloud-fb5vv4641-hack-club-bot.vercel.app/0image.png)
 
 Hey, isn't that just a cone but with the tip cut out? We can do that with holes!
 
 Since you already know how to use holes (and are probably tired with my rambling), I'm not going to elaborate much. I'll just show pictures.
 
-![frust1](https://cloud-fb5vv4641-hack-club-bot.vercel.app/1image.png)
+![frust1](https://cdn.hackclub.com/rescue?url=https://cloud-fb5vv4641-hack-club-bot.vercel.app/1image.png)
 
-![f2](https://cloud-fb5vv4641-hack-club-bot.vercel.app/2image.png)
+![f2](https://cdn.hackclub.com/rescue?url=https://cloud-fb5vv4641-hack-club-bot.vercel.app/2image.png)
 
 Easy right? Shapes like this gets easier and easier to identify as you model more and more.
 
@@ -153,18 +153,18 @@ I'm just going to show some pictures of me making an easy cylinder pommel if you
 
 This simple cylinder pommel is just making each part separately, aligning and fusing. The tutorial video in the slides gives an even easier example that doesn't even include the center sphere.
 
-![c1](https://cloud-cof3vpycd-hack-club-bot.vercel.app/0image.png)
+![c1](https://cdn.hackclub.com/rescue?url=https://cloud-cof3vpycd-hack-club-bot.vercel.app/0image.png)
 
-![c2](https://cloud-cof3vpycd-hack-club-bot.vercel.app/1image.png)
+![c2](https://cdn.hackclub.com/rescue?url=https://cloud-cof3vpycd-hack-club-bot.vercel.app/1image.png)
 
-![c3](https://cloud-cof3vpycd-hack-club-bot.vercel.app/2image.png)
+![c3](https://cdn.hackclub.com/rescue?url=https://cloud-cof3vpycd-hack-club-bot.vercel.app/2image.png)
 
 
 ## Fusing the Pieces
 
 Let's look at our inventory.
 
-![Inventory](https://cloud-bl0ftjpng-hack-club-bot.vercel.app/0image.png)
+![Inventory](https://cdn.hackclub.com/rescue?url=https://cloud-bl0ftjpng-hack-club-bot.vercel.app/0image.png)
 
 (I just made all of them a bit smaller because TinkerCAD was yelling at me about a size limit... oops)
 
@@ -172,7 +172,7 @@ A video of the fusing process is within the slides again, but this is basically 
 
 After some resizing and combination, we are (FINALLY) done!
 
-![End product](https://cloud-bl0ftjpng-hack-club-bot.vercel.app/1image.png)
+![End product](https://cdn.hackclub.com/rescue?url=https://cloud-bl0ftjpng-hack-club-bot.vercel.app/1image.png)
 
 (You can recolor parts by ungrouping it, then recoloring each piece by selecting it, clicking the "solid" button, and pressing a different color.)
 

--- a/jams/batches/3d-armory/readMe/en-US.md
+++ b/jams/batches/3d-armory/readMe/en-US.md
@@ -3,7 +3,7 @@ title: 'Forge of Legends: Crafting Weapons, Shields, and Armor in TinkerCAD'
 description: >  
   In this Jam, you'll be creating an awesome sword (or other item) in TinkerCAD. You will learn valuable skills around not only how to 3D model the sword example but also generally the ways designers think of their objects. Building something tangible while learning important concepts - two birds with one stone!
 contributor: 'thesuperRL'  
-thumbnail: 'https://cloud-c6t1n4k65-hack-club-bot.vercel.app/0000image__4___1__50.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-c6t1n4k65-hack-club-bot.vercel.app/0000image__4___1__50.webp'
 timeEstimate: '70 Min'  
 difficulty: 'Beginner-Intermediate' 
 keywords: '3D, Sword, CAD, 3D Design, Model, TinkerCAD, 3D Printing'  

--- a/jams/batches/artificial-intelligence/part-1/en-US.md
+++ b/jams/batches/artificial-intelligence/part-1/en-US.md
@@ -6,7 +6,7 @@ description: >
   This is a workshop description introducing the concept of Artificial Intelligence and Machine Learning, focusing on creating a web-based AI Companion or Smart Voice Assistant using HTML, JS, and CSS, as well as tools like Teachable Machine by Google and Replit, and incorporating OpenAI API to recognize an audio or visual keyword, with examples of different ideas for AI Companions.
 contributor: 'sahitid' 
 contributorSlackID: 'U03RU99SGKA'
-thumbnail: 'https://cloud-aatku17lm-hack-club-bot.vercel.app/0thumbnail_1.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-aatku17lm-hack-club-bot.vercel.app/0thumbnail_1.png'
 timeEstimate: '45 Min'  
 difficulty: 'Beginner'
 keywords: 'Machine Learning, Artificial Intelligence, AI, ML, chatgpt, openai, ai, ai api'  
@@ -24,7 +24,7 @@ totalParts: 4
 
 So what is artificial intelligence and machine learning? And what can you do with them?
 
-<video src="https://cloud-ckyxamknp-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-ckyxamknp-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
 *(here's an example of what you'll create by the end of this jams. Your AI & ML model will be unique to you and serve a completely different purpose!)*
 
 **We're going to be making an AI Companion or Smart Voice Assistant in your browser!**
@@ -64,7 +64,7 @@ You may be familiar already with smart voice assistants such as Siri, Alexa, or 
 
 You will be building a similar program. Call it, and it will turn on. It will turn your speech into text, and then input your transcript into a GPT model (through an API). The GPT model will then create a response which is turned into speech. The program will essentially talk back to you.
 
-![diagram detailing the parts of our project](https://cloud-essfp77oh-hack-club-bot.vercel.app/0group_1.png)
+![diagram detailing the parts of our project](https://cdn.hackclub.com/rescue?url=https://cloud-essfp77oh-hack-club-bot.vercel.app/0group_1.png)
 
 In this part, we'll be training the model to detect when the keyword is evoked with Teachable Machine.
 
@@ -74,13 +74,13 @@ We're going to be starting with teachable machine, a web-based tool that allows 
 
 We want to make sure that our AI Companion can recognize an audio or visual keyword! Just like a smart voice assistant:
 
-![](https://cloud-iosp3gjlp-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-iosp3gjlp-hack-club-bot.vercel.app/0image.png)
 
 Head over to [Teachable Machine](https://teachablemachine.withgoogle.com/train) and create a new project. I'm going to be creating an audio project! Keep in mind that you can use any of the three projects; your keyword could be a key-hand-motion or key-object that is held in front of the camera.
 
 Anything that is obvious enough to be detected in order to prompt the AI Companion will work here!
 
-![teachable machine dashboard](https://cloud-cffjo14g3-hack-club-bot.vercel.app/0screenshot_2023-06-27_154600.png)
+![teachable machine dashboard](https://cdn.hackclub.com/rescue?url=https://cloud-cffjo14g3-hack-club-bot.vercel.app/0screenshot_2023-06-27_154600.png)
 
 Once you choose your project from the dashboard, you should see the different classes. Let's focus on what we want to train the model to learn/look out for first.
 
@@ -88,17 +88,17 @@ Once you choose your project from the dashboard, you should see the different cl
 
 I want my AI Orpheus to respond to me whenever I say "Orpheus". Rename Class 2 to match your keyword, and don't copy mine! Your AI Companion should be completely your own.
 
-![renaming teachable machine classes](https://cloud-jefx2fwob-hack-club-bot.vercel.app/0teachable.gif)
+![renaming teachable machine classes](https://cdn.hackclub.com/rescue?url=https://cloud-jefx2fwob-hack-club-bot.vercel.app/0teachable.gif)
 
 It's almost as if you have two piles of stickers. Think of each sticker as a sample of training data.
 
 You can add existing stickers (or samples) to the piles (or classes) to make it more clear what the characteristics of each class are.
 
-![two piles of stickers](https://cloud-7cg6bj1c5-hack-club-bot.vercel.app/0img_8125.jpg)
+![two piles of stickers](https://cdn.hackclub.com/rescue?url=https://cloud-7cg6bj1c5-hack-club-bot.vercel.app/0img_8125.jpg)
 
 Then the machine learning model can take and entirely new sample that you give it as input and use the data in the existing classes to sort it.
 
-![sorting stickers into respective piles based on existing data](https://cloud-jjpf3syuu-hack-club-bot.vercel.app/0jams_gifs__1_.gif)
+![sorting stickers into respective piles based on existing data](https://cdn.hackclub.com/rescue?url=https://cloud-jjpf3syuu-hack-club-bot.vercel.app/0jams_gifs__1_.gif)
 
 ## Train Your Model
 
@@ -114,7 +114,7 @@ If I had even more stickers in the piles it would be even easier to sort new sti
 
 Also make sure to record lots of silence and background noise as well in different settings (in a classroom, hallway, outside, alone, etc) so the model is good at detecting when nothing is being said. We want there to be a clear distinction between when the keyword is said vs. when it is not said.
 
-![adding audio samples to teachable machine classes](https://cloud-lmzin6jbg-hack-club-bot.vercel.app/0website_gifs.gif)
+![adding audio samples to teachable machine classes](https://cdn.hackclub.com/rescue?url=https://cloud-lmzin6jbg-hack-club-bot.vercel.app/0website_gifs.gif)
 
 ## Finish and Export
 
@@ -124,27 +124,27 @@ And you don't have to stop there: try creating another class that'll make it eas
 
 For example, I know the word "amorphous" sort of sounds like Orpheus, but isn't exactly the keyword. Currently, the model still gets a little confused and assumes that someone saying "amorphous" is partially saying Orpheus.
 
-![false keyword detected](https://cloud-3kt0jz704-hack-club-bot.vercel.app/0screenshot_2023-06-28_105128.png)
+![false keyword detected](https://cdn.hackclub.com/rescue?url=https://cloud-3kt0jz704-hack-club-bot.vercel.app/0screenshot_2023-06-28_105128.png)
 
 I'm going to make a separate class for the word "amorphous" so it no longer confuses the model.
 
 Back to our sticker and basket analogy, this is just me creating another basket so people aren't confused on where to put stickers when sorting them.
 
-![sorting sticker into wrong pile](https://cloud-b0mbeaace-hack-club-bot.vercel.app/0ad30c6eb-346a-4ba3-aa9e-954783f524a9_1.gif)
+![sorting sticker into wrong pile](https://cdn.hackclub.com/rescue?url=https://cloud-b0mbeaace-hack-club-bot.vercel.app/0ad30c6eb-346a-4ba3-aa9e-954783f524a9_1.gif)
 
 Look at the image below. Now the model is less confused when I say the similar-sounding-but-not-actually-the-keyword word.
 
-![teachable machine recognizes false keyword](https://cloud-hvxyjcxd6-hack-club-bot.vercel.app/0screenshot_2023-06-28_105711.png)
+![teachable machine recognizes false keyword](https://cdn.hackclub.com/rescue?url=https://cloud-hvxyjcxd6-hack-club-bot.vercel.app/0screenshot_2023-06-28_105711.png)
 
 You've essentially created another pile!
 
-![sorting sticker into correct pile](https://cloud-mjrezffaw-hack-club-bot.vercel.app/0975da332-06c1-4bf0-95d7-e35546326741.gif)
+![sorting sticker into correct pile](https://cdn.hackclub.com/rescue?url=https://cloud-mjrezffaw-hack-club-bot.vercel.app/0975da332-06c1-4bf0-95d7-e35546326741.gif)
 
 ### Click the Export Model Button
 
 Once you're here you should see an "Update my cloud model" button. Make sure you do this!
 
-![update my cloud model button](https://cloud-crblb6kcm-hack-club-bot.vercel.app/0screenshot_2023-06-28_142611.png)
+![update my cloud model button](https://cdn.hackclub.com/rescue?url=https://cloud-crblb6kcm-hack-club-bot.vercel.app/0screenshot_2023-06-28_142611.png)
 
 Now you can show off your work by sending people the shareable link.
 
@@ -152,7 +152,7 @@ To finish our model we'll **copy the shareable link as well as the tensorflow.js
 
 Make sure to save your teachable machine to drive so it can be accessed later. Next time, instead of creating a new project, you can open this existing project from drive.
 
-![saving project to drive](https://cloud-iibkonedk-hack-club-bot.vercel.app/0image.png)
+![saving project to drive](https://cdn.hackclub.com/rescue?url=https://cloud-iibkonedk-hack-club-bot.vercel.app/0image.png)
 
 Great! Now you've finished with the teachable machine. You've trained a machine learning model with a dataset to understand and recognize when it's being called to "turn on".
 
@@ -173,7 +173,7 @@ If you're having difficulty using the site try https://firewalledreplit.com/ or 
 
 Welcome to your Replit Dashboard. Once inside, tap "+ Creat a Repl" and then select the HTML, CSS, and JavaScript template.  
 
-![Replit Signup](https://cloud-c6z75ah46-hack-club-bot.vercel.app/0export_jun_15_2023_0159_pm.gif)
+![Replit Signup](https://cdn.hackclub.com/rescue?url=https://cloud-c6z75ah46-hack-club-bot.vercel.app/0export_jun_15_2023_0159_pm.gif)
 
 You should now have three files. Rename them to be: index.html, script.js, and style.css respectively.
 
@@ -190,7 +190,7 @@ Yay! We've just created the following two constants:
 1. `URL` represents the URL of the Teachable Machine model we will be using
 2. `THRESHOLD` represents the confidence threshold for recognizing a specific word
 
-![teachable machine output](https://cloud-f437a9orj-hack-club-bot.vercel.app/0image.png)
+![teachable machine output](https://cdn.hackclub.com/rescue?url=https://cloud-f437a9orj-hack-club-bot.vercel.app/0image.png)
 *(Feel free to set the threshold number to any amount you like! I've got it set for 90% or higher accuracy in recognition. This is essentially that output bar you see moving in the teachable machine).*
 
 Now we are going to create one big function that all the other functions + our teachable machine code will sit inside. It's an event handler that runs once the window is finished loading to ensure that the code inside only runs after all the HTML content has been loaded:
@@ -359,14 +359,14 @@ Now on Replit open up your HTML "site" in a new tab. don't worry if it's blank! 
 
 Now click ctrl+shift+i to open the inspect element and move to the console tab. If you look under choices you'll be able to see the text that has come back!
 
-![console printing response to keyword being said](https://cloud-2sz1omo3w-hack-club-bot.vercel.app/0image.png)
+![console printing response to keyword being said](https://cdn.hackclub.com/rescue?url=https://cloud-2sz1omo3w-hack-club-bot.vercel.app/0image.png)
 
 Yay! Now watch the console print "Hey" every time you say the keyword!
 
 ## Additional Challenge Hacking! (recommended)
 
 The creation doesn't have to stop here! Here are some Jam Hacks™ that you can experiment with:
-![jam hacks](https://cloud-f7mhrygov-hack-club-bot.vercel.app/0jam_hacks_2.gif)
+![jam hacks](https://cdn.hackclub.com/rescue?url=https://cloud-f7mhrygov-hack-club-bot.vercel.app/0jam_hacks_2.gif)
 
 - I've made the keyword an audio one but what if we tried using a visual/image model instead? *(My friend Thomas is testing to see what would happen if the teachable machine was trained to notice if you raised your hand or waved a flag!*)
 - What would happen if you added multiple keywords?

--- a/jams/batches/artificial-intelligence/part-2/en-US.md
+++ b/jams/batches/artificial-intelligence/part-2/en-US.md
@@ -6,7 +6,7 @@ description: >
   This is a workshop description introducing the concept of Artificial Intelligence and Machine Learning, focusing on creating a web-based AI Companion or Smart Voice Assistant using HTML, JS, and CSS, as well as tools like Teachable Machine by Google and Replit, and incorporating OpenAI API to recognize an audio or visual keyword, with examples of different ideas for AI Companions.
 contributor: 'sahitid'  
 contributorSlackID: 'U03RU99SGKA'
-thumbnail: 'https://cloud-1xtor5uxe-hack-club-bot.vercel.app/0thumbnail_2.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-1xtor5uxe-hack-club-bot.vercel.app/0thumbnail_2.png'
 timeEstimate: '45 Min'  
 difficulty: 'Beginner'
 keywords: 'Machine Learning, Artificial Intelligence, AI, ML, chatgpt, openai, ai, ai api'  
@@ -28,7 +28,7 @@ Although this Jams goes over the fundamentals of using AI and ML, reign all your
 
 In fact I encourage that you go out of your way to think of the most bizarre uses of your program. Take a look at what an AI came up with as ideas.
 
-![chatgpt response with ideas for projects](https://cloud-jmwnkv7lq-hack-club-bot.vercel.app/0image.png)
+![chatgpt response with ideas for projects](https://cdn.hackclub.com/rescue?url=https://cloud-jmwnkv7lq-hack-club-bot.vercel.app/0image.png)
 
 In this part, we'll start coding our web app with JavaScript and HTML to set up our speech to text feature, start listening function, and stop listening function!
 
@@ -75,7 +75,7 @@ Some of these will be invisible at first, so let's add some CSS:
 
 ## Let's Get Orpheus to Speak!
 
-![orpheus plushie gif](https://cloud-lsz4bcbfi-hack-club-bot.vercel.app/0jams_gifs.gif)
+![orpheus plushie gif](https://cdn.hackclub.com/rescue?url=https://cloud-lsz4bcbfi-hack-club-bot.vercel.app/0jams_gifs.gif)
 
 Now we can create the two functions to first output the response through text onto the screen and then to output the speech
 
@@ -156,7 +156,7 @@ recognizer.listen(
 
 In case it wasn't obvious enough, here is what we changed:
 
-![before and after for code](https://cloud-8s76y8brd-hack-club-bot.vercel.app/0jams_gifs.png)
+![before and after for code](https://cdn.hackclub.com/rescue?url=https://cloud-8s76y8brd-hack-club-bot.vercel.app/0jams_gifs.png)
 
 Notice that we replaced `console.log` with `speak('Hey!').then(() => ...)`. Because we used promises, we can say, once speak is done done running, we can **then** move on to the next thing, which is `console.log`ging "Done speaking
 
@@ -273,12 +273,12 @@ window.onload = () => {
 }
 ```
 
-<video src="https://cloud-18r0fzw3m-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-18r0fzw3m-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
 
 ## Additional Challenge Hacking! (recommended)
 
 It's that time you've all been waiting for! Let's Hack our Jam! Try doing one of the following:
-![jam hacks](https://cloud-f7mhrygov-hack-club-bot.vercel.app/0jam_hacks_2.gif)
+![jam hacks](https://cdn.hackclub.com/rescue?url=https://cloud-f7mhrygov-hack-club-bot.vercel.app/0jam_hacks_2.gif)
 
 - Try adding a setting that lets people choose their voice option
 - Have you ever looked into [Eleven Labs](https://beta.elevenlabs.io/) AI voices? How might one go about incorporating their API into this project for more realistic voices?

--- a/jams/batches/artificial-intelligence/part-3/en-US.md
+++ b/jams/batches/artificial-intelligence/part-3/en-US.md
@@ -6,7 +6,7 @@ description: >
   This is a workshop description introducing the concept of Artificial Intelligence and Machine Learning, focusing on creating a web-based AI Companion or Smart Voice Assistant using HTML, JS, and CSS, as well as tools like Teachable Machine by Google and Replit, and incorporating OpenAI API to recognize an audio or visual keyword, with examples of different ideas for AI Companions.
 contributor: 'sahitid'  
 contributorSlackID: 'U03RU99SGKA'
-thumbnail: 'https://cloud-pn240umd6-hack-club-bot.vercel.app/0thumbnail_3.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-pn240umd6-hack-club-bot.vercel.app/0thumbnail_3.png'
 timeEstimate: '45 Min'  
 difficulty: 'Beginner'
 keywords: 'Machine Learning, Artificial Intelligence, AI, ML, chatgpt, openai, ai, ai api'  
@@ -28,11 +28,11 @@ Welcome back to our little journey to create a walking talking Orpheus AI Compan
 
 In the first part of the Jams, we used Teachable machine to train a model in order to recognize the keyword "Orpheus". We then used the Replit online IDE to create an empty site that would print a message in the console every time the keyword was detected to be said.
 
-![console printing response to keyword being said](https://cloud-2sz1omo3w-hack-club-bot.vercel.app/0image.png)
+![console printing response to keyword being said](https://cdn.hackclub.com/rescue?url=https://cloud-2sz1omo3w-hack-club-bot.vercel.app/0image.png)
 
 In the second part of the Jams, we gave Orpheus a voice! Now instead of printing out a message in the console, our AI Companion would speak and say it out loud.
 
-<video src="https://cloud-18r0fzw3m-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-18r0fzw3m-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
 Now in the third part of the Jams, we will allow Orpheus to convert the speech that we say when we talk to it into text.
 
 *Reminder: If you're ever stuck or confused ~~or have a spelling mistake in your code that your IDE isn't catching but continues to break the whole program~~, try asking [AI such as ChatGPT](https://chat.openai.com/) to figure it out for you!*
@@ -116,7 +116,7 @@ recognizer.listen(
 
 Here's the edit you just made, if it's not obvious enough.
 
-![before and after image](https://cloud-oqe6fu130-hack-club-bot.vercel.app/0jams_gifs.png)
+![before and after image](https://cdn.hackclub.com/rescue?url=https://cloud-oqe6fu130-hack-club-bot.vercel.app/0jams_gifs.png)
 
 ## See It In Action!
 
@@ -126,7 +126,7 @@ Try saying the keyword and Orpheus will say "Hey" back.
 
 Now try saying something else to your AI Companion and watch as it `console.log`s what you said! Woah! 
 
-![console.log of speech](https://cloud-mzlajhso5-hack-club-bot.vercel.app/0image.png)
+![console.log of speech](https://cdn.hackclub.com/rescue?url=https://cloud-mzlajhso5-hack-club-bot.vercel.app/0image.png)
 
 And now do you see how useful promises are? We can wait for `speak()` to finish before we start `hear()`ing, and then only after the computer is done hearing do we log the message.
 
@@ -169,12 +169,12 @@ Now the process is:
 
 Yay! Now Orpheus can hear you and convert your voice into text.
 
-![final demo of speech being printed as text on screen](https://cloud-d37x8o6qj-hack-club-bot.vercel.app/0image.png)
+![final demo of speech being printed as text on screen](https://cdn.hackclub.com/rescue?url=https://cloud-d37x8o6qj-hack-club-bot.vercel.app/0image.png)
 
 ## Additional Challenge Hacking! (recommended)
 
 It's that time you've all been waiting for! Let's Hack our Jam! Try doing one of the following:
-![jam hacks](https://cloud-f7mhrygov-hack-club-bot.vercel.app/0jam_hacks_2.gif)
+![jam hacks](https://cdn.hackclub.com/rescue?url=https://cloud-f7mhrygov-hack-club-bot.vercel.app/0jam_hacks_2.gif)
 
 - Change up your character! We're doing Orpheus but you don't have to.
 - Our UI is also going to look like a smart phone & text messaging system. But I encourage everyone to do their own play on this AI Companion. What if your screen has a sound visualizer?

--- a/jams/batches/artificial-intelligence/part-4/en-US.md
+++ b/jams/batches/artificial-intelligence/part-4/en-US.md
@@ -6,7 +6,7 @@ description: >
   This is a workshop description introducing the concept of Artificial Intelligence and Machine Learning, focusing on creating a web-based AI Companion or Smart Voice Assistant using HTML, JS, and CSS, as well as tools like Teachable Machine by Google and Replit, and incorporating OpenAI API to recognize an audio or visual keyword, with examples of different ideas for AI Companions.
 contributor: 'sahitid'  
 contributorSlackID: 'U03RU99SGKA'
-thumbnail: 'https://cloud-bq06l4opt-hack-club-bot.vercel.app/0thumbnail_4.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-bq06l4opt-hack-club-bot.vercel.app/0thumbnail_4.png'
 timeEstimate: '45 Min'  
 difficulty: 'Beginner'
 keywords: 'Machine Learning, Artificial Intelligence, AI, ML, chatgpt, openai, ai, ai api'  
@@ -27,11 +27,11 @@ AITokenLink: "https://hackclub.slack.com/archives/C05L8BSDJJ3"
 
 In the first part of the Jams, we used Teachable machine to train a model in order to recognize the keyword "Orpheus". We then used the Replit online IDE to create an empty site that would print a message in the console every time the keyword was detected to be said.
 
-![console printing response to keyword being said](https://cloud-2sz1omo3w-hack-club-bot.vercel.app/0image.png)
+![console printing response to keyword being said](https://cdn.hackclub.com/rescue?url=https://cloud-2sz1omo3w-hack-club-bot.vercel.app/0image.png)
 
 In the second part of the Jams, we gave Orpheus a voice! Now instead of printing out a message in the console, our AI Companion would speak and say it out loud.
 
-<video src="https://cloud-18r0fzw3m-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-18r0fzw3m-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
 In the third part of the Jams, we gave Orpheus the power to convert our speech into text.
 
 Now, in the fourth and final part, we will finally incorporate the OpenAI API to utilize the GPT 3.5 model. Ever heard of ChatGPT? OpenAI built it and invested years and billions of dollars to create the dataset that you will be using for your AI Companion.
@@ -47,14 +47,14 @@ Now, in the fourth and final part, we will finally incorporate the OpenAI API to
 1. Make an account and login to https://platform.openai.com/
 2. Go to API keys and create a new API key. *Make sure to save it! never share it! As you can see in the demo, we haven't provided our own API key in the project for this reason.*
 
-![API keys on OpenAI](https://cloud-n3hgshowm-hack-club-bot.vercel.app/0image.png)
+![API keys on OpenAI](https://cdn.hackclub.com/rescue?url=https://cloud-n3hgshowm-hack-club-bot.vercel.app/0image.png)
 
 We will be using GPT-3.5 or GPT-4, the most accessible and recently updated set of models that can understand & generate both natural language and code. There are also [models](https://platform.openai.com/docs/models/overview) such as Whisper (that can convert audio into text) or Dall-e (that can generate and edit images based on a prompt).
 
 ##### There's Two Parts to Implementing a Text Model
 Firstly, the AI needs to be able to generate its own ideas. Next, the AI must complete text suggestions, such as how Google tries to guess what you're searching.
 
-![google autocomplete](https://cloud-ae241kl1y-hack-club-bot.vercel.app/0image.png)
+![google autocomplete](https://cdn.hackclub.com/rescue?url=https://cloud-ae241kl1y-hack-club-bot.vercel.app/0image.png)
 
 This will allow us to have a conversation with the AI!
 
@@ -67,7 +67,7 @@ APIs are really simple! there's 4 main requests for HTTP request methods:
 
 > APIs (or Application Programming Interfaces) are like a digital restaurant, they are the waiter that goes between you (the client) and the kitchen (the server). Requests are sent from you the client to the server to perform actions.
 
-![digital restaurant gif](https://cloud-lk53rqdly-hack-club-bot.vercel.app/0bb312c00-400b-4da4-bc6a-6fbd2a91cca4.gif)
+![digital restaurant gif](https://cdn.hackclub.com/rescue?url=https://cloud-lk53rqdly-hack-club-bot.vercel.app/0bb312c00-400b-4da4-bc6a-6fbd2a91cca4.gif)
 
 <table>
   <thead>
@@ -161,7 +161,7 @@ Tokens are common sequences of characters found in text and what the models use 
 
 The OpenAI tokenizer (https://platform.openai.com/tokenizer) can be used to visually demonstrate how an API would tokenize a string of text, as well as how many tokens it would be.
 
-![tokenizer](https://cloud-1sxrk5p2x-hack-club-bot.vercel.app/0image.png)
+![tokenizer](https://cdn.hackclub.com/rescue?url=https://cloud-1sxrk5p2x-hack-club-bot.vercel.app/0image.png)
 
 *General rule: 1 token generally corresponds to ~4 characters of text for common English text or 3/4 of a word. this is roughly 100 tokens ~= 75 words.*
 
@@ -525,12 +525,12 @@ html {
 ```
 
 ## Final Demo
-<video src="https://cloud-ckyxamknp-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-ckyxamknp-hack-club-bot.vercel.app/0jams_gifs__1_.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
 
 ## Additional Challenge Hacking! (recommended)
 
 It's that time you've all been waiting for! Let's Hack our Jam! Try doing one of the following:
-![jam hacks](https://cloud-f7mhrygov-hack-club-bot.vercel.app/0jam_hacks_2.gif)
+![jam hacks](https://cdn.hackclub.com/rescue?url=https://cloud-f7mhrygov-hack-club-bot.vercel.app/0jam_hacks_2.gif)
 
 Use any one of the APIs in your own project. Here are some examples:
 
@@ -544,4 +544,4 @@ Use any one of the APIs in your own project. Here are some examples:
 
 You've created a project with artificial intelligence and machine learning. Now go forth and be hacky!
 
-![orpheus celebration dance](https://cloud-12ntu5q74-hack-club-bot.vercel.app/0jams_gifs__1_.gif)
+![orpheus celebration dance](https://cdn.hackclub.com/rescue?url=https://cloud-12ntu5q74-hack-club-bot.vercel.app/0jams_gifs__1_.gif)

--- a/jams/batches/artificial-intelligence/readMe/en-US.md
+++ b/jams/batches/artificial-intelligence/readMe/en-US.md
@@ -4,11 +4,11 @@ contributor: 'sahitid'
 contributorSlackID: 'U03RU99SGKA'
 description: "Let's build our own AI companion! My companion is going to be Orpheus (you might have heard of her ;) but by the end of this jam, you'll have your own AI best friend."
 video: ''
-thumbnail: 'https://cloud-dzrl19x7a-hack-club-bot.vercel.app/00overall_thumbnail.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-dzrl19x7a-hack-club-bot.vercel.app/00overall_thumbnail.webp'
 keywords: 'AI, ML, Machine Learning, Artificial Intelligence'
 timeEstimate: '4 Hours'
 difficulty: 'Beginner'
 slug: 'artificial-intelligence'
-sticker: 'https://cloud-10lbh4zg4-hack-club-bot.vercel.app/0000frame_101__1_-2.webp'
+sticker: 'https://cdn.hackclub.com/rescue?url=https://cloud-10lbh4zg4-hack-club-bot.vercel.app/0000frame_101__1_-2.webp'
 isBatch: True
 ---

--- a/jams/batches/oscillart/part-2/en-US.md
+++ b/jams/batches/oscillart/part-2/en-US.md
@@ -6,7 +6,7 @@ title: 'Playing Sounds with Sine Waves'
 description: "In this part of the Jam, you'll use Javascript's Web Audio API to play sounds from your browser given by user-input."
 contributor: "celesteroselli"
 contributorSlackID: 'U06TV3F4HEU'
-thumbnail: 'https://hc-cdn.hel1.your-objectstorage.com/s/v3/4b0f8950436ef1090644a20cca1722a0e9a9d1f3_untitled_design__26_.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/4b0f8950436ef1090644a20cca1722a0e9a9d1f3_untitled_design__26_.png'
 timeEstimate: '30-45 min'
 difficulty: 'Beginner, Intermediate'
 keywords: 'music, wave, frequency, javascript, art'
@@ -39,7 +39,7 @@ First, go to the left side of the codespaces environment, where all your project
 
 Pssst, here’s a quick screenshare if you missed any of that:
 
-<video src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/129d6de090147b0813e4fb4f8b8fe516fe43e984_screen_recording_2025-06-06_at_3.40.17___pm.mov.mp4" width="100%" controls></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/129d6de090147b0813e4fb4f8b8fe516fe43e984_screen_recording_2025-06-06_at_3.40.17___pm.mov.mp4" width="100%" controls></video>
 
 Yay!! You have an HTML file! Let’s start adding some elements to it. First, add the following code inside of the `<body>...</body>` tags:
 
@@ -193,7 +193,7 @@ Now, all we have to do is call the handle function whenever the button is presse
 
 Now, press the **Live Server** button at the bottom toolbar. And now, in your site, type in the number of hertz in a note (aka the frequency) into your textbox. For example, to play the note A in the middle of your piano, you use the frequency of 440 Hz. So type that into your textbox, and hit the button. You should hear that note played coming out of your browser for one second! Now, change the number so it’s higher, maybe 600 or so. Hit the button again. Is the tone that got played higher-pitched than the last one? It should be! Here's what mine looks like:
 
-<video src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/020eee5f6f011c8875ac2adc5f3fabae75093591_part1.mp4" width="100%" controls></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/020eee5f6f011c8875ac2adc5f3fabae75093591_part1.mp4" width="100%" controls></video>
 
 <br />
 <br />
@@ -259,7 +259,7 @@ Yay!! You’ve done it! If you add a note name into your textbox (or whatever yo
 
 Here's my result:
 
-<video src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/31ed37a81aea5cafc7c37b593612265685a3e102_scale1.mp4" width="100%" controls></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/31ed37a81aea5cafc7c37b593612265685a3e102_scale1.mp4" width="100%" controls></video>
 
 <br />
 

--- a/jams/batches/oscillart/part-3/en-US.md
+++ b/jams/batches/oscillart/part-3/en-US.md
@@ -6,7 +6,7 @@ title: 'Drawing Sine Waves on the JS Canvas'
 description: "In this part of the Jam, you'll draw the sine waves that you're hearing on JS's canvas, creating your first art designs."
 contributor: "celesteroselli"
 contributorSlackID: 'U06TV3F4HEU'
-thumbnail: 'https://hc-cdn.hel1.your-objectstorage.com/s/v3/be97f69ac117aac3db0ed6d9d6da6862fd3dfa71_untitled_design__27_.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/be97f69ac117aac3db0ed6d9d6da6862fd3dfa71_untitled_design__27_.png'
 timeEstimate: '30-45 min'
 difficulty: 'Beginner, Intermediate'
 keywords: 'art, music, waves, javascript, canvas'
@@ -53,7 +53,7 @@ Copy the following into your style.css file:
 
 Now, what this does is add a black border around our canvas, keep it at a stable height and width, and add a little margin underneath it, so that it doesn’t run into our button (em is a unit of thickness by the way). Here's what mine looks like:
 
-![image of canvas](https://hc-cdn.hel1.your-objectstorage.com/s/v3/a8166444eb15926661847e2988f538c64d8939b3_screenshot_2025-06-08_at_1.29.51___pm.png)
+![image of canvas](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/a8166444eb15926661847e2988f538c64d8939b3_screenshot_2025-06-08_at_1.29.51___pm.png)
 
 So you know for the future, we use `#<id-name>` to add styles to an element with a unique ID, `.<class-name>` to refer to elements with shared classes, and simply the element name to add styles to all elements of that type.
 
@@ -98,7 +98,7 @@ Then, we’re going to be using the following methods:
 
 And, this isn’t a coding method, but here’s a helpful math equation when creating your function:
 
-![equation of sine waves](https://hc-cdn.hel1.your-objectstorage.com/s/v3/9c0e592bffc7573402d4b629f52be60ba5155773_screenshot_2025-06-10_at_12.11.06___pm.png)
+![equation of sine waves](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/9c0e592bffc7573402d4b629f52be60ba5155773_screenshot_2025-06-10_at_12.11.06___pm.png)
 
 <Dropdown title="Here’s a MEGA challenge: can you code this function all on your own? I believe in you! Don’t worry about including any loops or trying to call it as an interval; we’ll do that later. Just try and create a function that, if called intervally, would draw a sine wave. Make sure to use that equation I gave you!! And, call it line(). Pssst… Make sure to increase x by 1 at the end!">
 
@@ -203,7 +203,7 @@ Now, let’s add drawWave to our handle function, so that when we press our subm
 
 You should have a working web app that plays both music and art when you press a button!! Here's my result:
 
-<video src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/16a23c6547279ae957baa2712b7e4e0e796ec602_drawscale.mp4" width="100%" controls></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/16a23c6547279ae957baa2712b7e4e0e796ec602_drawscale.mp4" width="100%" controls></video>
 
 <br />
 

--- a/jams/batches/oscillart/part-4/en-US.md
+++ b/jams/batches/oscillart/part-4/en-US.md
@@ -6,7 +6,7 @@ title: 'Write Full Songs and Melodies'
 description: "In this part of the Jam, you'll use loops to use your app to create full songs and complex melodies."
 contributor: "celesteroselli"
 contributorSlackID: 'U06TV3F4HEU'
-thumbnail: 'https://hc-cdn.hel1.your-objectstorage.com/s/v3/72b9b84489a40f839f7d97f3e0ecd4e97e366f23_1.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/72b9b84489a40f839f7d97f3e0ecd4e97e366f23_1.png'
 timeEstimate: '1 hr'
 difficulty: 'Beginner, Intermediate'
 keywords: 'music, songs, melodies, javascript'
@@ -48,7 +48,7 @@ for (i = 0; i < usernotes.length; i++) {
 
 Now, what this does is create a loop that uses the variable i to **iterate** through the numbers 0 until the note before the end of your list length. The way indexes work in javascript is that the last number’s (let's declare the nunmber as n) index will be **n-1**. Here’s a diagram to help explain it:
 
-![javascript index diagram](https://hc-cdn.hel1.your-objectstorage.com/s/v3/8f5293dbe91459c9a31a444f6b84ba6db81cc053_index.png)
+![javascript index diagram](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/8f5293dbe91459c9a31a444f6b84ba6db81cc053_index.png)
 
 Now, to keep track of all of the notes that users have in their input, let’s create an **array** to hold the notes, called **noteslist**. Make sure to do this *before* your for-loop. Here are the following methods regarding arrays you should know:
 
@@ -124,7 +124,7 @@ Now, this code means that every 2 seconds, frequency will play a new note and dr
 
 But if we run our code, we run into a few issues…
 
-<video src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/306036ad306181fa751fc2a42a53ad363686ea17_notesissue.mp4" width="100%" controls></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/306036ad306181fa751fc2a42a53ad363686ea17_notesissue.mp4" width="100%" controls></video>
 
 <br />
 
@@ -168,7 +168,7 @@ gainNode.gain.setValueAtTime(0, audioCtx.currentTime + 0.9);
 
 Now, if you type in multiple note names into the text box, and run your code, you should see all of those notes be played and be drawn on your canvas, and you should hear them all too! Here's my example:
 
-<video src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/2e25f09c3bdbe0660d0a11b4de41499b83536169_4waves.mp4" width="100%" controls></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/2e25f09c3bdbe0660d0a11b4de41499b83536169_4waves.mp4" width="100%" controls></video>
 
 <br />
 
@@ -243,7 +243,7 @@ Finally, to make sure that we’re ending the interval after the correct amount 
 
 Now, if we press our button after inputting a lot more notes, like 4 or 5…
 
-<video src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/246c5f953ebfca718787658e6fbcef7bcb869725_spacedout.mp4" width="100%" controls></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/246c5f953ebfca718787658e6fbcef7bcb869725_spacedout.mp4" width="100%" controls></video>
 
 <br />
 

--- a/jams/batches/oscillart/part-5/en-US.md
+++ b/jams/batches/oscillart/part-5/en-US.md
@@ -6,7 +6,7 @@ title: 'Add in User Input and Customization'
 description: "In this part of the Jam, you'll add sliders and inputs so your user can customize your art and music."
 contributor: "celesteroselli"
 contributorSlackID: 'U06TV3F4HEU'
-thumbnail: 'https://hc-cdn.hel1.your-objectstorage.com/s/v3/e2205fabe35fae365098c1fd3501b322504dac6b_1__1_.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/e2205fabe35fae365098c1fd3501b322504dac6b_1__1_.png'
 timeEstimate: '30-45 min'
 difficulty: 'Beginner, Intermediate'
 keywords: 'art, color, input, button, javascript'
@@ -78,7 +78,7 @@ Answer:
 
 Yay!! If you run your code now, while adjusting the color picker, you should notice something… 
 
-<video src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/c7ba76ec303f75c9dccab2cb0fcca713aedd807f_color.mp4" width="100%" controls></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/c7ba76ec303f75c9dccab2cb0fcca713aedd807f_color.mp4" width="100%" controls></video>
 
 <br />
 
@@ -90,23 +90,23 @@ That’s right! Your line is changing color! You’re one step closer to an awes
 
 **Ok, we’ve gotten it all artsy up in here with our majestic palettes of customizable colors.**
 
-![art-orpheus](https://hc-cdn.hel1.your-objectstorage.com/s/v3/2d121580ca3c44438bfd1068158f93f1cab58bed_artorpheus.jpeg)
+![art-orpheus](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/2d121580ca3c44438bfd1068158f93f1cab58bed_artorpheus.jpeg)
 
 Credit to @Jordi (Jordan)
 
 **But let’s get it funky up in here.**
 
-![dj-1](https://hc-cdn.hel1.your-objectstorage.com/s/v3/a0ad58660dc0575aa0043fe166733ce65981a742_dj1.jpg)
+![dj-1](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/a0ad58660dc0575aa0043fe166733ce65981a742_dj1.jpg)
 
 Credit to @Space_Duck (Navya M)
 
-![dj-2](https://hc-cdn.hel1.your-objectstorage.com/s/v3/0d62c4789fd87525a4ace7ae7b4e3b0b56d11629_dj2.jpeg)
+![dj-2](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/0d62c4789fd87525a4ace7ae7b4e3b0b56d11629_dj2.jpeg)
 
 Credit to @Jordi (Jordan)
 
 In this section, we’re going to be giving users the ability to change the volume of the sound that comes out of their laptop. In addition, this change will **also affect the drawn sine waves**, because in real-life, waves with higher volumes have higher **amplitudes**! So, when the user increases volume on a slider, not only will the sound come out louder, but their waves will be taller.
 
-![diagram of volume and amplitude](https://hc-cdn.hel1.your-objectstorage.com/s/v3/2441a2227b8c9793f044245f44e5a2033d6fa78c_screenshot_2025-06-06_at_12.50.36___pm.png)
+![diagram of volume and amplitude](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/2441a2227b8c9793f044245f44e5a2033d6fa78c_screenshot_2025-06-06_at_12.50.36___pm.png)
 
 Let’s start by adding a slider input, which is gonna control the volume/amplitude. Add this to your index.html around where you added the color picker:
 
@@ -203,7 +203,7 @@ Now, to clean up your code, go ahead and get rid of the amplitude value wherever
 
 If you run your code…
 
-<video src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/5d78eec3ceb31ab8560ad174ff87640fc512c881_realvolume.mp4" width="100%" controls></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/5d78eec3ceb31ab8560ad174ff87640fc512c881_realvolume.mp4" width="100%" controls></video>
 
 <br />
 

--- a/jams/batches/oscillart/part-7/en-US.md
+++ b/jams/batches/oscillart/part-7/en-US.md
@@ -6,7 +6,7 @@ title: 'Styling and Shipping'
 description: "In this part of the Jam, you'll finalize your app design with CSS and ship it using GitHub pages."
 contributor: "celesteroselli"
 contributorSlackID: 'U06TV3F4HEU'
-thumbnail: 'https://hc-cdn.hel1.your-objectstorage.com/s/v3/a775a91ea2c5e600296aae5274a84ed1a8e85188_1__3_.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/a775a91ea2c5e600296aae5274a84ed1a8e85188_1__3_.png'
 timeEstimate: '30-45 min'
 difficulty: 'Beginner, Intermediate'
 keywords: 'shipping, deploying, github pages, CSS, style'
@@ -97,7 +97,7 @@ The styles you might want to use use here:
 
 I used all of the methods above in my stylesheet to customize my site. Here’s my end result!
 
-![oscillart demo picture](https://hc-cdn.hel1.your-objectstorage.com/s/v3/72ebb828de43d89615be69cd44ed04451e968888_screenshot_2025-06-06_at_1.03.12___pm.png)
+![oscillart demo picture](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/72ebb828de43d89615be69cd44ed04451e968888_screenshot_2025-06-06_at_1.03.12___pm.png)
 
 Now that I’ve gone through my suggestions, here are some ideas on what you could customize on your own. W3Schools is my favorite site for finding CSS inspiration. Go off and explore!
 - Background images
@@ -108,7 +108,7 @@ Now that I’ve gone through my suggestions, here are some ideas on what you cou
 
 ## Section 2: time to ship!
 
-![dancing-orpheus-gif](https://hc-cdn.hel1.your-objectstorage.com/s/v3/f606f18cca43d719f3e9aecaa9a6c23fd37baade_orpheus.gif)
+![dancing-orpheus-gif](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/f606f18cca43d719f3e9aecaa9a6c23fd37baade_orpheus.gif)
 
 🎉🥳 ***WHOOP WHOOP WHOOP PARTY TIME PARTY PARTY TIME*** 🥳🎉
 
@@ -120,23 +120,23 @@ In addition, if you’re completing this project for the Athena awards, by shipp
 
 We’re going to publish our sites to a URL using **GitHub Pages**. To do so, follow these steps:
 
-![instructions #1](https://hc-cdn.hel1.your-objectstorage.com/s/v3/6134cbcedc6488f68621ebd8d2443c889f56a190_screenshot_2025-06-06_at_1.11.44___pm.png)
+![instructions #1](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/6134cbcedc6488f68621ebd8d2443c889f56a190_screenshot_2025-06-06_at_1.11.44___pm.png)
 
 1. Go to your GitHub repository
 
-![instructions #2](https://hc-cdn.hel1.your-objectstorage.com/s/v3/3ffe0b814f2e3e21de6919d8b8d187e67ba064bb_screenshot_2025-06-06_at_1.12.56___pm.png)
+![instructions #2](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/3ffe0b814f2e3e21de6919d8b8d187e67ba064bb_screenshot_2025-06-06_at_1.12.56___pm.png)
 
 2. Go to Settings
 
-![instructions #3](https://hc-cdn.hel1.your-objectstorage.com/s/v3/62a2848d3066a5a90bc3736c7e7394dcb31d2ad5_screenshot_2025-06-05_at_11.18.45___am.png)
+![instructions #3](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/62a2848d3066a5a90bc3736c7e7394dcb31d2ad5_screenshot_2025-06-05_at_11.18.45___am.png)
 
 3. On the left menu bar, click on Pages
 
-![instructions #4](https://hc-cdn.hel1.your-objectstorage.com/s/v3/404ac5c32ff39d88e3ccdec134df62ca4c93690c_screenshot_2025-06-05_at_11.19.36___am.png)
+![instructions #4](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/404ac5c32ff39d88e3ccdec134df62ca4c93690c_screenshot_2025-06-05_at_11.19.36___am.png)
 
 4. Under Build and Deployment, then under Branch, click on None and in the dropdown, select Main
 
-![instructions #5](https://hc-cdn.hel1.your-objectstorage.com/s/v3/cdb25d39224dc06b0b09948c70c3915c831de226_screenshot_2025-06-05_at_11.20.30___am.png)
+![instructions #5](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/cdb25d39224dc06b0b09948c70c3915c831de226_screenshot_2025-06-05_at_11.20.30___am.png)
 
 5. Refresh the page, then click the URL after “Your site is live at…” at the top
 
@@ -150,7 +150,7 @@ Remember that pesky README file we created when we initialized our repository? N
 
 Go back to your GitHub repository, and click on the file README.md.
 
-![readme file](https://hc-cdn.hel1.your-objectstorage.com/s/v3/2bd1375419f0a4daf5dff26aa1da88d95c33f485_screenshot_2025-06-09_at_11.21.22___am.png)
+![readme file](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/2bd1375419f0a4daf5dff26aa1da88d95c33f485_screenshot_2025-06-09_at_11.21.22___am.png)
 
 Inside it, include some info about your project! README's are written in Markdown, so you can include plain text here, but if you want some extra features (like headers, bolding text, links, etc.) check out this [link](https://www.markdownguide.org/). Here are some ideas to get started:
 
@@ -164,7 +164,7 @@ Inside it, include some info about your project! README's are written in Markdow
 
 Then, when you're done, don't forget to click the green "Commit Changes" button in the top righthand corner!
 
-![readme file open](https://hc-cdn.hel1.your-objectstorage.com/s/v3/bd3a4af0d7c73843a02fcf86778574ed9ec44c4e_screenshot_2025-06-09_at_11.22.35___am.png)
+![readme file open](https://cdn.hackclub.com/rescue?url=https://hc-cdn.hel1.your-objectstorage.com/s/v3/bd3a4af0d7c73843a02fcf86778574ed9ec44c4e_screenshot_2025-06-09_at_11.22.35___am.png)
 
 <br />
 

--- a/jams/batches/sparkletilt-pcb/part-1/en-US.md
+++ b/jams/batches/sparkletilt-pcb/part-1/en-US.md
@@ -3,7 +3,7 @@ title: 'Microcontroller Circuit Design'
 description: 'Design an Arduino Nano-compatible microcontroller board in KiCAD'
 contributor: 'karmanyaahm'
 contributorSlackID: 'U04CNFV0T4M'
-thumbnail: 'https://cloud-k9knyyk0j-hack-club-bot.vercel.app/00thumb.jpg'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-k9knyyk0j-hack-club-bot.vercel.app/00thumb.jpg'
 timeEstimate: '1 hour' # ???
 difficulty: 'Intermediate'
 keywords: 'PCB, KiCAD, electronics, schematic, Atmel, ATMega328P, Arduino, microcontroller, circuit'
@@ -23,7 +23,7 @@ Let's design an Arduino Nano-compatible microcontroller board using KiCAD!
 
 If you follow through these 4 jams, your finished SparkleTilt will look something like this - but with your very own design customizations!
 
-![](https://cloud-izep2lpej-hack-club-bot.vercel.app/031picture.jpg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-izep2lpej-hack-club-bot.vercel.app/031picture.jpg)
 
 
 <details>
@@ -67,7 +67,7 @@ First, we place the heart of our system, the ATmega328P-AU, in a TQFP package [S
 
 ### Power
 
-![](https://cloud-j48wmzjac-hack-club-bot.vercel.app/21.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-j48wmzjac-hack-club-bot.vercel.app/21.webp)
 
 Then, we need to connect the power pins to power *nets* and place *decoupling capacitors*.
 
@@ -81,7 +81,7 @@ Your *reference designator* numbers for C may be different from the image (C1 an
 
 ### Clock
 
-![](https://cloud-j48wmzjac-hack-club-bot.vercel.app/32.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-j48wmzjac-hack-club-bot.vercel.app/32.webp)
 The datasheet for our crystal, C13738, shows that pins 2 and 4 are connected to ground [Search: Crystal_GND24].
 
 Now that our MCU is powered, it needs a clock to tick to[^3]. We can configure the ATmega328P to use this 16MHz crystal rather than run at its default of 1MHz.
@@ -103,7 +103,7 @@ So, we use 12pF capacitors.
 [^3]: Yes, while the ATmega328P does have an internal clock, it's kinda inaccurate and could cause issues with serial communications. The simple and safe choice is to use an external crystal which are typically accurate to 20 parts per million, a opposed to the 5% (5 parts per hundred) of the ATmega's intenal clock.
 
 ### Reset
-![](https://cloud-j48wmzjac-hack-club-bot.vercel.app/43.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-j48wmzjac-hack-club-bot.vercel.app/43.webp)
 
 The bar on top of RESET means that it is active low, GND (0V) will reset the MCU and it should be at VCC (5V) during normal operation. The SPST button here is JLCPCB's basic push button which connects RESET to ground when pressed [Search: SW_SPST]. 
 
@@ -114,7 +114,7 @@ Labeling this wire as RESET connects it to the RESET *net*. If we place another 
 
 ### Label Pinout
 
-![image](https://cloud-j48wmzjac-hack-club-bot.vercel.app/54.webp)
+![image](https://cdn.hackclub.com/rescue?url=https://cloud-j48wmzjac-hack-club-bot.vercel.app/54.webp)
 
 After this, we need labels telling us which MCU pin is which Arduino Nano pin.
 
@@ -122,7 +122,7 @@ These are global labels. Unlike the RESET label, these work on all pages of the 
 
 ## Headers
 
-![](https://cloud-nbfq15yho-hack-club-bot.vercel.app/15.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-nbfq15yho-hack-club-bot.vercel.app/15.png)
 
 First, we have the traditional Arduino Nano pinout [Search: Arduino_Nano_v3] connected to our labels, telling the ECAD software we want these headers connected to the prespecified microcontroller pins. Since this whole board is running at 5V, just mark 3V3 as NC (No Connect).
 
@@ -134,7 +134,7 @@ Once you have a label, you can press 'x' to flip it horizontally.
 
 We start with the 16 Pin USB 2.0 Type C receptacle, C165948.
 
-![image](https://cloud-mu5k1d6dk-hack-club-bot.vercel.app/1usb.png)
+![image](https://cdn.hackclub.com/rescue?url=https://cloud-mu5k1d6dk-hack-club-bot.vercel.app/1usb.png)
 
 NC: SBU1/2 and Shield/Shell (shield is only for hosts).
 
@@ -146,12 +146,12 @@ Since we will be powering a bunch of LEDs, I picked a big diode JLCPCB had as a 
 
 Then, to tell the USB-C port that we are drawing power from it, CC1 and CC2 have to each be connected through separate 5.1k resistors to ground[^4]. That tells the USB-C power adapter that we can draw up to 5V 3A.
 
-You can download the KiCAD CH340N footprint here: [ch340n.kicad_sym](https://cloud-b6v3rkn29-hack-club-bot.vercel.app/0ch340n.kicad_sym). Then, put it in your project folder and add it to your symbol library in Preferences > Manage Symbol Libraries > Project Specific Libraries.
+You can download the KiCAD CH340N footprint here: [ch340n.kicad_sym](https://cdn.hackclub.com/rescue?url=https://cloud-b6v3rkn29-hack-club-bot.vercel.app/0ch340n.kicad_sym). Then, put it in your project folder and add it to your symbol library in Preferences > Manage Symbol Libraries > Project Specific Libraries.
 
-![](https://cloud-j48wmzjac-hack-club-bot.vercel.app/87.1.webp)
-![](https://cloud-j48wmzjac-hack-club-bot.vercel.app/97.2.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-j48wmzjac-hack-club-bot.vercel.app/87.1.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-j48wmzjac-hack-club-bot.vercel.app/97.2.webp)
 
-![image](https://cloud-mu5k1d6dk-hack-club-bot.vercel.app/0ch.png)
+![image](https://cdn.hackclub.com/rescue?url=https://cloud-mu5k1d6dk-hack-club-bot.vercel.app/0ch.png)
 
 Now, we can connect our UART chip, the CH340N. Both D+ and D- from the USB-C connector go to D+/- on the CH340N. As specified in its datasheet, both V3 and VCC get 100nF decoupling capacitors. RTS goes to RESET through another 100nF capacitor; this capacitor makes the RESET pin briefly pulse low instead of staying low forever (avoiding bootlooping the MCU).
 
@@ -163,7 +163,7 @@ RXD and TXD (USB directionality), are connected to their microcontroller pins D1
 
 Now you have a simple Arduino Nano-compatible board schematic! Check out Part 2 to turn this into a PCB, or jump to Part 3 to add more features to this board[^2].
 
-![](https://cloud-mu5k1d6dk-hack-club-bot.vercel.app/201full-kicad.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-mu5k1d6dk-hack-club-bot.vercel.app/201full-kicad.svg)
 
 {/* footnotes */}
 

--- a/jams/batches/sparkletilt-pcb/part-2/en-US.md
+++ b/jams/batches/sparkletilt-pcb/part-2/en-US.md
@@ -3,7 +3,7 @@ title: 'Turn a KiCAD Schematic into a PCB'
 description: 'Turn a microcontroller schematic into a real PCB layout'
 contributor: 'karmanyaahm'
 contributorSlackID: 'U04CNFV0T4M'
-thumbnail: 'https://cloud-r3x168b9x-hack-club-bot.vercel.app/5552.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/5552.webp'
 timeEstimate: '3 hours' # ??
 difficulty: 'Intermediate'
 keywords: 'PCB, KiCAD, electronics, schematic, Atmel, ATMega328P, Arduino, microcontroller, circuit'
@@ -67,19 +67,19 @@ Footprints are the exposed copper pads on the PCB for each component. They repre
 
 First, click on 'Run footprint assignment tool'.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/100.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/100.webp)
 
 In the new window, under Footprint Filters, select the first one - "filters defined in symbol" - but deselect the other two.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/10.1.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/10.1.webp)
 
 Now, you should have a window like this with some footprints autofilled, others empty.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/20.2.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/20.2.webp)
 
 Some footprints, like the Arduino Nano outline, which is not a real component in this case, only have a few options. Double-click on `Module:Arduino_Nano_WithMountingHoles` to select it.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/30.3.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/30.3.webp)
 
 ### Generics
 
@@ -89,7 +89,7 @@ Some footprints, like the Arduino Nano outline, which is not a real component in
 
 To find our first capacitor, go to [jlcpcb.com/parts](https://jlcpcb.com/parts). In this case, we will search for 100nF, our first capacitor.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/40.4.png.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/40.4.png.webp)
 
 Then, scroll down and **select "Basic Parts"** to find the parts that don't have the extended fee and we see that they do have 0805 available. So, click on the component and search for 0805 in footprint selection. Do this for each component.
 
@@ -104,15 +104,15 @@ all LEDs will be `LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder`, and al
 
 If you look up the Diode `C35722`, you will get its LCSC page, which says the package is `SMC(DO-214AB)`.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/50.5.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/50.5.webp)
 
 Going to the Datasheet also confirms this.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/60.6.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/60.6.webp)
 
 Then, in KiCAD, after selecting the diode, we can search for the package. While there are no results for DO-214, SMC shows up and we can select `Diode_SMD:D_SMC_Handsoldering`.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/70.7.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/70.7.webp)
 
 Do the same reseach with the Crystal to get the footprint/package.
 
@@ -126,7 +126,7 @@ Looking up the part number, C13738, for the crystal on [jlcpcb.com/parts](https:
 
 Similarly, for the ICSP header, you will get the right result by searching for `2.54mm` (i.e. 0.1 inch pin spacing), and `2x03` (6 pins arranged in 2x3): `Connector_PinHeader_2.54mm:PinHeader_2x03_P2.54mm_Vertical`.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/80.8.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/80.8.webp)
 
 
 ### Other components
@@ -140,22 +140,22 @@ Lastly, some components like the USB-C Receptacle can be weird. While there are 
 ---
 
 Now that our footprints are all selected, we can move on to the PCB!
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/90.9.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/90.9.webp)
 
 
 ## PCB
 
 ### Setup
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/231.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/231.webp)
 
 Click 'Open PCB in board editor' in the schematic view.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/342.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/342.webp)
 
 In the PCB editor, click on 'Edit board setup'. This is where we will set the constraints of our design.
 
-![](https://cloud-h0ccsbxz9-hack-club-bot.vercel.app/06.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-h0ccsbxz9-hack-club-bot.vercel.app/06.png)
 
 Then, in Design Rules > Pre-defined Sizes, specify how wide you want your traces, vias, and differential pairs will be. KiCAD will let you pick between the options here when designing your board. We will set a track width of 0.3mm for signal traces, 0.5mm for power traces, and 0.7mm diameter vias with a 0.3mm hole[^6]. 
 
@@ -165,33 +165,33 @@ Then, press OK to save and exit board setup.
 
 ### Set Up Components
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/617.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/617.webp)
 
 Now, in the board editor window, clicking on 'Update PCB with schematic' brings in all your components to the PCB page. If you make schematic changes, you can click on this to bring in your new parts. In the Update PCB window options, check Delete footprints and Replace footprints and click on Update PCB.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/628.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/628.webp)
 
 Place them off to the side for now.
 
 
 ### Board Edges
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/639.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/639.webp)
 
 Now, to define the edges of our board, select the `Edge.Cuts` layer in the layer menu.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/1110.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/1110.webp)
 
 You can use the shape tools to draw the outline of the board, or...
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/1211.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/1211.webp)
 
 you can go to File > Import > Graphics to import a custom **SVG**. You can **pick whatever shape you like here**.
 
 > *Note*: In part 3 of this jam, we will be adding more features such as an LED strip and accelerometer to make a level. Make sure your design will support the physical realities of being a level, such as having two points to balance on, which do not have any ports. Also, consider how your LEDs will physically and aesthetically fit.  Make a rough paper sketch if that helps.
 > Of course, none of this applies to you if you have different plans for your board.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/1312.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/1312.webp)
 
 By default, your drawing probably won't fit the Arduino Nano template.
 
@@ -199,13 +199,13 @@ Delete the first import and go back to File > Import > Graphics. Play with the s
 
 > This step will take some trial and error.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/1413.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/1413.webp)
 
 Clean up the drawing to only leave one continuous board shape.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/1615.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/1615.webp)
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/1514.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/1514.webp)
 
 Double-click the shape and set it up like the image above.
 - Not Locked
@@ -220,7 +220,7 @@ Double-click the shape and set it up like the image above.
 
 > Note: Many of the choices in this section will depend upon your outline. Feel free to ask for help in [#onboard-help](https://hackclub.slack.com/archives/C0593MG26TT) on Slack.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/1817.a.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/1817.a.webp)
 
 After you position the Board Edge and Arduino Template, lock them in place (Select Both > Right Click > Locking > Lock) to avoid accidentally moving them.
 
@@ -232,30 +232,30 @@ Then, start placing the major components: USB Port, ICs, Microcontroller, button
 
 Rotate them to a position that'll make running traces convenient. For example, you want the D+ and D- pins of the USB controller to be facing the port, and the TX, RX pins to be facing your microcontroller. You can rotate things 90 degrees by pressing 'R' on your keyboard, or set a 45 degree offset for the MCU by going to properties.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/1917.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/1917.webp)
 
 This is how I roughly laid out the core components within the Arduino Nano footprint. Some large components like the reset switch and diode are outside the main nano footprint. The red pads indicate that these are all on the `F.Cu` layer. This is the front of the PCB. While a typical Nano design needs to be two-sided (have components on both the front and back) to fit within that footprint, here, we will make a larger, one-sided board to keep assembly costs down.
 
 > You have to be clever and very deliberate with the placement for your components so minimize the amount of wiring going around other things. Spending a little bit more time on this step will make your routing life sooo much easier. Take inspiration from my layout, but you can't just copy it becase my reference numbers are different. Look at the schematic and see which component connects to what.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/2018.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/2018.webp)
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/2219.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/2219.webp)
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/2119.5.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/2119.5.webp)
 
 
 > Note: This layout took several rounds of iteration between layout and trace routing to generate. It's absolutely fine, and in fact, necessary to come back to rearrange your components if you find your layout doesn't work when routing traces. If this is your first complex board, you'll quickly find that learning routing is the most tedious part of your board, but obviously necessary to get your board working.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/2420.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/2420.webp)
 
 While laying out your board, the 3D viewer is a very useful tool. Use "Alt+3" to open it.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/2521.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/2521.webp)
 
 If some components are not visible, go back to your board design and double-click the part to open properties.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/2622.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/2622.webp)
 
 Make sure you're in properties for the whole component, not just one pad or silkscreen, and then open the '3D Models' tab. Click on the file browser for the 3D model line. These are the correct models:
 
@@ -271,7 +271,7 @@ To route tracks, follow the Ratsnest (thin blue lines connecting matching nets),
 
 Try to use the higher thickness 0.5mm trace for sensitive applications like the decoupling capacitors, clock, power lines, etc if you can fit it, and 0.3mm for regular data lines[^6].
 
-![](https://cloud-mu5k1d6dk-hack-club-bot.vercel.app/4screenshot_20230921_041203.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-mu5k1d6dk-hack-club-bot.vercel.app/4screenshot_20230921_041203.png)
 
 The following images are how router the traces:
 
@@ -279,13 +279,13 @@ Note: You can press "x" when hovering over a pad to start a trace.
 
 In the Appearance sidebar go to Objects > Locked Item Shadow, and hide it to clean up your layout a little bit. Feel free to play with the opacities of other elements to get to a point that you are comfortable with.
 
-![](https://cloud-5127rirqc-hack-club-bot.vercel.app/023.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-5127rirqc-hack-club-bot.vercel.app/023.webp)
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/2824.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/2824.webp)
 
 The purple lines are the 'Courtyard' - they show you how close two components can be without physically interfering, so, you keep the decoupling capacitor and IC's courtyards very close to each other.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/2925.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/2925.webp)
 
 And then, connect the microcontroller pins. In my layout A0-A5, D0, D1, D5-D13 can be routed on the top layer as shown above.
 
@@ -298,19 +298,19 @@ Now because there is no way to connect D4 of the microcontroller to the header p
 
 First, press 'X' to start running a trace away from D4, towards the inside of the microcontroller.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/3026.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/3026.webp)
 
 Move to some empty space then press 'v' to create a via.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/3127.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/3127.webp)
 
 Click to place the via, and now you can drag a blue trace - on the back side of the board.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/3228.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/3228.webp)
 
 Click on D4. Since D4 and other pins are through holes, you can connect traces from either layer to them.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/3329.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/3329.webp)
 
 Just like D4, use vias on A6, A7, D2, and D3 to reach their respective header pins. 
 - If your via is too close to a pad, solder might flow into it and prevent the pad from being properly attached. So, even though KiCAD doesn't stop you from doing that, stay a safe distance away from pads.
@@ -318,22 +318,22 @@ Just like D4, use vias on A6, A7, D2, and D3 to reach their respective header pi
 
 You can click on the blue `B.Cu` layer in the Layers sidebar to visually bring the back layer traces to the front.
 
-![](https://cloud-5127rirqc-hack-club-bot.vercel.app/130.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-5127rirqc-hack-club-bot.vercel.app/130.webp)
 
 Just like that, use vias and thoughtful crossings to connect D0/D1 to the USB chip and D11/12/13 to the ICSP header. However try to minimize the length of traces on the back, because of the [ground plane](#Ground%20Plane) we will later put in.
 
 
 ### The other tracks
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/3631.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/3631.webp)
 
 And then you can run the Reset track.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/3732.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/3732.webp)
 
 And VCC.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/3833.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/3833.webp)
 
 And then a little bit of finagling with the A6, A7, and D13 vias lets us run VBUS under the Microcontroller, straight up to the USB port.
 
@@ -344,29 +344,29 @@ Now, we only have ground pins left, and for that, we'll do something special.
 A ground plane is a large continuous chunk of copper on a layer. It creates a low impedance i.e. clean and easy path for ground current to return. (Because physics) Having an adjacent ground plane also reduces the interference between parallel traces.  More complex 4 layer boards might even have a plane for VCC power. In this board, the ground plane will take up all the unoccupied space on the `B.Cu` layer.
 
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/3934.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/3934.webp)
 
 First, click on 'Add a filled zone'.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/4035.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/4035.webp)
 
 Then, click on a point far outside the edge of the board and set up the Copper Zone to be connected to ground, and to remove islands below 10mm^2.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/4136.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/4136.webp)
 
 Then, draw a shape encompassing the whole board and press 'B' to build the plane.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/4237.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/4237.webp)
 
 You should play with Zone opacity in the Objects sidebar to find something good for you.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/4338.webp)
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/4439.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/4338.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/4439.webp)
 
 Then, start dropping vias from ground pads. Press escape when it draws a blue trace, you only need the via here.
 
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/4640.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/4640.webp)
 
 The through-holes should connect themselves to the ground plane.
 This is what all the grounds look like.
@@ -380,16 +380,16 @@ This is what all the grounds look like.
 This could be useful if you want to mount your board onto a breadboard but don't have soldering equipment.
 
 Go back to your schematic and add these two `Conn_01x15_Pin` symbols and connect them to the correct nets.
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/5653.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/5653.webp)
 
 > Note how D0/D1 are flipped relative to the rest of the pins.
 
 In the footprint selection window, select `PinHeader_1x15_P2.54mm_Vertical` for both.
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/5754.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/5754.webp)
 
 Update your board to sync it with the schematic and then position the new pins on top of the old ones.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/5855.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/5855.webp)
 You might have to zoom in to get the holes perfectly concentric.
 
 Lock the new pins in place (Right Click > Locking > Lock) and delete the old Arduino layout.
@@ -404,11 +404,11 @@ Additionally, you might want to add pin labels on the back silkscreen layer (whe
 The Design Rules Checker (DRC) looks at the constraints we set the board up with and finds problems in the design.
 
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/4741.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/4741.webp)
 
 After you run the DRC with Refilling and Parity checks, you should see a bunch of errors.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/4842.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/4842.webp)
 
 Sooo, there's 90 issues. That's not good. Luckily, the vast majority of them are inconsequential.
 
@@ -422,19 +422,19 @@ The most important issues are in the Unconnected Items tab:
 
 Turned out, the part of the ground plane that connected to this GND pin was disconnected from the rest [^2], so make it like this:
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/4944.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/4944.webp)
 
 The ground plane island highlighted another issue with this design. If you follow the current flow from the USB port to the bottom plane, it turns out the whole thing relies on one .3mm connection under the clock.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/5045.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/5045.webp)
 
 Fortunately, there's an easy solution: double-click the ground plane to open properties and change its clearance and minimum width to .3mm.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/5146.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/5146.webp)
 
 Then, the ground plane goes in between the planes and it's a continuous chunk again.
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/5247.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/5247.webp)
 
 And now our board is electrically done!
 
@@ -446,10 +446,10 @@ You can solve other DRC issues pretty easily.
 
 
 ## Finished Board
-![](https://cloud-596d7k8lu-hack-club-bot.vercel.app/11longhorn_leds-brd.svg)
-![](https://cloud-1tut81n9o-hack-club-bot.vercel.app/0longhorn_leds-B_Cu.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-596d7k8lu-hack-club-bot.vercel.app/11longhorn_leds-brd.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-1tut81n9o-hack-club-bot.vercel.app/0longhorn_leds-B_Cu.svg)
 
-![](https://cloud-r3x168b9x-hack-club-bot.vercel.app/5552.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-r3x168b9x-hack-club-bot.vercel.app/5552.webp)
 
 {/* will automatically have footnotes header */}
 [^1]: More info at https://eepower.com/resistor-guide/resistor-standards-and-codes/resistor-sizes-and-packages/#

--- a/jams/batches/sparkletilt-pcb/part-3/en-US.md
+++ b/jams/batches/sparkletilt-pcb/part-3/en-US.md
@@ -3,7 +3,7 @@ title: 'Adding Peripherals'
 description: 'Add useful sensors, chargers, and lights to your dev board'
 contributor: 'karmanyaahm'
 contributorSlackID: 'U04CNFV0T4M'
-thumbnail: 'https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/32thumb.jpg'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/32thumb.jpg'
 timeEstimate: '3 hours' # ???
 difficulty: 'Difficult'
 keywords: 'PCB, KiCAD, electronics, schematic, Atmel, ATMega328P, Arduino, microcontroller, circuit'
@@ -76,16 +76,16 @@ The rest of the parts are:
 There are 3 modifications you need to make to the old design to suit the new power layout.
 
 1. Connect the new power rails to the right pins.  
-   ![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/192.webp)
-2. The USB chip now runs off 3.3V VCC, and according to [the datasheet](https://cdn.sparkfun.com/datasheets/Dev/Arduino/Other/CH340DS1.PDF), V3 and VCC need to be connected together to 3.3V. Also, lower the resistance for the LEDs because of the lower voltage. ![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/233.webp)
-3. Change the Diode to our new one, and USB is now powering VBUS and USB_P (5V rail). ![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/244.webp)
+   ![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/192.webp)
+2. The USB chip now runs off 3.3V VCC, and according to [the datasheet](https://cdn.sparkfun.com/datasheets/Dev/Arduino/Other/CH340DS1.PDF), V3 and VCC need to be connected together to 3.3V. Also, lower the resistance for the LEDs because of the lower voltage. ![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/233.webp)
+3. Change the Diode to our new one, and USB is now powering VBUS and USB_P (5V rail). ![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/244.webp)
 
 
 ## Other peripherals
 
 First, create a new sheet called "Devices" to store everything else and place it on your schematic.
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/255.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/255.webp)
 
 Now, you have a whole new page to store your components.
 
@@ -93,7 +93,7 @@ Now, you have a whole new page to store your components.
 
 In 'Section 4: Application Hints' of the [LIS3DH datasheet](https://www.st.com/resource/en/datasheet/lis3dh.pdf), you'll see an example circuit and descriptions for what you're supposed to do to each pin. You can also look at other OSHW circuits (ex. Adafruit, Sparkfun) to understand the application of such an IC.
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/266.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/266.webp)
 
 Here, everything is powered from the 3.3V VCC. There are two decoupling capacitors (100nF and 10uF) as required by the datasheet. The two 4.7K resistors pull the I2C line high when it's not being used. CS is tied high to enable I2C communication at all times. The interrupts are not being used here since we don't need data immediately[^5].
 
@@ -101,27 +101,27 @@ Here, everything is powered from the 3.3V VCC. There are two decoupling capacito
 
 This is a simple set of switches that can be read with the microcontroller's internal pullup pins and will let us define aspects of the LEDs and Level in software. Consider using something that has protruding switches and is (significantly) bigger than the C40737 if you want to control it by hand.
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/277.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/277.webp)
 
 ### Battery Charging
 
-[The datasheet](https://cloud-b6v3rkn29-hack-club-bot.vercel.app/1tp4057-google-translated-datasheet.pdf) for the TP4057 recommends this circuit if we want the Red LED to light up when it's charging, the Green LED when it's charged, and both lights off if no battery is connected.
+[The datasheet](https://cdn.hackclub.com/rescue?url=https://cloud-b6v3rkn29-hack-club-bot.vercel.app/1tp4057-google-translated-datasheet.pdf) for the TP4057 recommends this circuit if we want the Red LED to light up when it's charging, the Green LED when it's charged, and both lights off if no battery is connected.
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/010.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/010.webp)
 
 The PROG resistor determines how fast to charge the battery based on a formula, some common values are in the datasheet:
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/299.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/299.webp)
 
 Lithium batteries should typically only be charged with up to 1C of current[^8]. For example, if you have a 300mAh battery, 1C = 300mA of charge or discharge current. Since this is an LED project, it'll require big batteries (> 500mAh), so we'll select 500mA as the charging current with a 1.6k resistor[^7].
 
 This is the final schematic:
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/288.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/288.webp)
 
 
 ### Power Processing
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/212.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/212.webp)
 
 > KiCAD doesn't have a TP4057 symbol by default, see the [Component Listing](#Component%20Listing) to download it.
 
@@ -141,7 +141,7 @@ This is called a Power ORing circuit.
 
 So, I have a battery (say +3V min) and USB (nominally +5V). I want to drive VDrive from the USB when it's connected, else the battery. This is the simplest way to do that:
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/314.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/314.webp)
 
 Here, the VBat Diode has one job: Protect the battery from charging directly through USB. This is because when VDrive (the junction point) is at 5V due to USB (maybe 4.6V due to the diodes), the potential at VDrive is higher than the potential at VBat. Since current flows from higher to lower potential (voltage), it won't flow from the battery (`<4.2V`) to VDrive (`>4.5V`). The diode (being a one-way valve) won't allow USB current into the battery.
 
@@ -149,7 +149,7 @@ The VBUS Diode prevents the battery from powering the charger, possible power LE
 
 Now, why is our MOSFET design better? It seems far more complicated. But, the trick is that instead of a fixed voltage drop, turning the MOSFET on causes the drop to be ~40 mOhms. At 1A, that is a .04V drop - significantly better than the diode's ~.3V. Not only does this save energy, it allows you to use the battery down to a lower voltage.
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/415.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/415.webp)
 
 There are 3 states to this MOSFET arrangement[^10]:
 1. VBUS is 5V, VBAT is 4V. `(G - S) > -1`. MOSFET does not conduct. Additionally, since `S > D`, no potential gets applied backward onto the battery.
@@ -161,7 +161,7 @@ There are 3 states to this MOSFET arrangement[^10]:
 
 Additionally, the USB interface should already be protected in case VBUS is powered by the header pin.
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/244.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/244.webp)
 
 This design is why current coming from USB to VDrive has two diodes, and thus we picked diodes with a 0.25V to 0.65V drop (ideally a constant .3V). 
 
@@ -169,7 +169,7 @@ This design is why current coming from USB to VDrive has two diodes, and thus we
 
 This is a chain of NeoPixels:
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/516.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/516.webp)
 
 The WS2812B symbol works for any WS2812 or SK6812 LED that has 4 pins (+, -, DIN, DOUT). Since they are all logically the same, different NeoPixel form factors use the same symbol with different PCB footprints. Although they are not required, we have a capacitor to aid with sudden bursts of energy and a resistor to stop too much current from going to the LED's data pin in case of a short[^11]. There's also a debug connector to test the LEDs from an external microcontroller, again, not required, just helpful in development.
 
@@ -186,35 +186,35 @@ From a circuit standpoint, putting LEDs in parallel is easy: you just connect th
 
 > **Note**: Carefully compare the datasheets if you're putting two different LEDs in parallel. Some LEDs are GRB, others are RGB, so won't be the same color if connected in parallel[^13].
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1122.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1122.webp)
 
 But, as you can see, it quickly turns into a mess. If you want to block sets of LEDs that will be together repeatedly (in series or in parallel) do this:
 
 First, add a hierarchical sheet called `LED_BLOCK`. Then, put something like this in it (for parallel). Since the power symbols are globally the same, you can put them inside this drawing rather than having to connect it to every single LED group.
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/617.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/617.webp)
 
 Then, add hierarchical labels from the right sidebar called "DIN" and "DOUT".
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/718.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/718.webp)
 
 Then, connect them to the right points. Notice how we're not connecting both the LEDs outputs; they would interfere with each other. One LED is doing the talking on DOUT, while the other is a passive listener.
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/819.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/819.webp)
 
 Go back to the DEVICES sheet. Then, click on 'Import a hierarchical sheet pin' to put the DIN and DOUT we defined in the last step to the outside of the block. You can delete the 'File' label.
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/920.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/920.webp)
 
 Then, copy-paste this sheet and connect it in a chain.
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1021.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1021.webp)
 
 If you copy and paste them, the blocks will be linked and making a change to one will propagate throughout the rest, making iteration easier.
 </details>
 
 ## Component Listing
 
-To add symbols, see the [CH340N from Part 1](./part-1#USB%20Interface). Just like that, in the PCB view, you can add custom footprint libraries. My custom symbols (TP4057) and footprints (LEDs) are in [custom-leds.pretty.zip](https://cloud-b6v3rkn29-hack-club-bot.vercel.app/2custom-leds.pretty.zip), which you need can extract into your KiCAD project folder. You could also find such footprints elsewhere on the internet, or create them from the datasheet.
+To add symbols, see the [CH340N from Part 1](./part-1#USB%20Interface). Just like that, in the PCB view, you can add custom footprint libraries. My custom symbols (TP4057) and footprints (LEDs) are in [custom-leds.pretty.zip](https://cdn.hackclub.com/rescue?url=https://cloud-b6v3rkn29-hack-club-bot.vercel.app/2custom-leds.pretty.zip), which you need can extract into your KiCAD project folder. You could also find such footprints elsewhere on the internet, or create them from the datasheet.
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/2131.webp)
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/2232.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/2131.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/2232.webp)
 
 
 
@@ -237,46 +237,46 @@ Since your board design will be very different from mine - with a different phys
 
 I replaced the one big diode with the accelerometer near the MCU, to make routing easier, since they both talk I2C and use 3.3V VCC. It's using 0402 components and .2mm traces to reasonably be able to route around the incredibly tiny pins.
 
-![](https://cloud-596d7k8lu-hack-club-bot.vercel.app/1123.png)
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1425.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-596d7k8lu-hack-club-bot.vercel.app/1123.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1425.webp)
 
 I also put the voltage regulator in that vicinity because everything that needs 3.3V VCC is inside the Arduino footprint.
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1324.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1324.webp)
 
 The two power diodes are off to one side, where I found some free space. That header pin is the only thing connected to VBUS, so centering the diodes approximately there reduces trace length.
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1526.webp)
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1627.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1526.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1627.webp)
 
 
 Then, the battery charger and connector are placed right next to the rest of the power management. 
 
 > I'd recommend flipping the connector compared to how I placed it in the image because the ICSP header is obstructing my clips.
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1728.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1728.webp)
 
 The switch is oriented (and wired in the schematic) in such a way that the switch pads and header pins are in a line.
 
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1829.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/1829.webp)
 
 And my overly complicated parallel LEDs were laid out as shown. Of course, you can't use both at the same time due to color encoding differences (see the [LEDs section on grouping](#LEDs)). The through-holes provide a free via to run VDrive on the other side and access the ground plane. If you have a peninsula like this, double-check that the ground plane isn't constricted through a bottleneck. There's no harm in running traces on top of the plane to ensure there's enough capacity.
-![](https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/2030.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/2030.webp)
 
 
 ## Final Design
 And that's it, you have a completed SparkleTilt!
 Full Board:
-![](https://cloud-596d7k8lu-hack-club-bot.vercel.app/6longhorn_leds-F_Cu.svg)
-![](https://cloud-596d7k8lu-hack-club-bot.vercel.app/2longhorn_leds-B_Cu.svg)
-![](https://cloud-596d7k8lu-hack-club-bot.vercel.app/7longhorn_leds-F_Fab.svg)
-![](https://cloud-596d7k8lu-hack-club-bot.vercel.app/3longhorn_leds-brd.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-596d7k8lu-hack-club-bot.vercel.app/6longhorn_leds-F_Cu.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-596d7k8lu-hack-club-bot.vercel.app/2longhorn_leds-B_Cu.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-596d7k8lu-hack-club-bot.vercel.app/7longhorn_leds-F_Fab.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-596d7k8lu-hack-club-bot.vercel.app/3longhorn_leds-brd.svg)
 
 This is the full schematic:
-![](https://cloud-596d7k8lu-hack-club-bot.vercel.app/8longhorn_leds.svg)
-![](https://cloud-596d7k8lu-hack-club-bot.vercel.app/5longhorn_leds-DEVICES_PAGE.svg)
-![](https://cloud-596d7k8lu-hack-club-bot.vercel.app/4longhorn_leds-DEVICES_PAGE-LED-stick0.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-596d7k8lu-hack-club-bot.vercel.app/8longhorn_leds.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-596d7k8lu-hack-club-bot.vercel.app/5longhorn_leds-DEVICES_PAGE.svg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-596d7k8lu-hack-club-bot.vercel.app/4longhorn_leds-DEVICES_PAGE-LED-stick0.svg)
 
 This is what my board looks like (the CH340N is missing because I messed up the traces in v1):
-![](https://cloud-izep2lpej-hack-club-bot.vercel.app/031picture.jpg)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-izep2lpej-hack-club-bot.vercel.app/031picture.jpg)
 
 I can't wait to see how you remix this. You can share your designs and get feedback in [#onboard on Slack](https://hackclub.slack.com/archives/C056AMWSFKJ). We'll discuss programming this board in Part 5 of this jam! (Coming Soon)
 
@@ -284,7 +284,7 @@ I can't wait to see how you remix this. You can share your designs and get feedb
 [^1]: https://learn.adafruit.com/li-ion-and-lipoly-batteries/voltages
 [^2]: In practice, you may see Neopixels running happily from 3.3V microcontrollers, but can't rely on that. The MCU's voltage might be on the lower end and output slightly under 3.3V, your USB line might be outputting 5.2V and now the limit is at 3.65V, etc. It's best to keep a margin of error.
 [^3]: https://youtu.be/osfgkFyq7lA?t=127
-[^4]: A DIP switch is a package with multiple individual switches like this: <img src="https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/301.jpg" width="50%" />
+[^4]: A DIP switch is a package with multiple individual switches like this: <img src="https://cdn.hackclub.com/rescue?url=https://cloud-rbtn9ts6c-hack-club-bot.vercel.app/301.jpg" width="50%" />
 [^5]: These interrupts would be useful if you needed an event notification from the IC (is acceleration > *n*?), or you wanted every single value immediately after it was measured (integrate acceleration to velocity) (AKA Pushing data). In our case, we'll just ask the chip for the acceleration every few hundred milliseconds (AKA Polling data).
 [^6]: See table on page 8 for more info.
 [^7]: I used 1.5k because 1.6ks were unavailable in my size on JLCPCB, anything around that ought to work. Similarly, I used a 4.7k instead of a 5k on the battery pin pull-up.

--- a/jams/batches/sparkletilt-pcb/part-4/en-US.md
+++ b/jams/batches/sparkletilt-pcb/part-4/en-US.md
@@ -3,7 +3,7 @@ title: 'Ordering a KiCAD board from JLCPCB'
 description: 'Learn how to convert a board design into an actual order'
 contributor: 'karmanyaahm'
 contributorSlackID: 'U04CNFV0T4M'
-thumbnail: 'https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/514.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/514.webp'
 timeEstimate: '1 hour'
 difficulty: 'Intermediate'
 keywords: 'PCB, KiCAD, electronics, schematic, Atmel, ATMega328P, Arduino, microcontroller, circuit'
@@ -36,11 +36,11 @@ Here are some component notes[^3]:
 
 Click on Plugin Manager on the KiCAD home page.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/111.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/111.webp)
 
 Search for 'JLC'.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/122.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/122.webp)
 
 Install 'Fabrication Toolkit' and apply changes.
 
@@ -49,11 +49,11 @@ Install 'Fabrication Toolkit' and apply changes.
 
 Open your schematic. Go to Bulk Edit fields.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/135.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/135.webp)
 
 In the Field Editor window, click on 'Add Field' and add the field `LCSC`. It doesn't matter whether you have `Sim.*` or `Datasheet` fields or not.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/146.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/146.webp)
 
 Then, search for your components at [jlcpcb.com/parts](https://jlcpcb.com/parts) and fill in the LCSC id.
 
@@ -63,11 +63,11 @@ You don't *have* to necessarily specify the part number for generic components l
 
 The LCSC Part number (aka JLCPCB Part #) looks like `Cxxxx`.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/157.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/157.webp)
 
 For more specific components, like the Atmega328P-AU, you should only have a couple of options and just pick the most popular one (Basic Part if possible).
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/168.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/168.webp)
 
 
 Try doing this yourself before you look at my version below.
@@ -76,7 +76,7 @@ Try doing this yourself before you look at my version below.
 
 <summary>This is what your table should look like, and then Apply and Save.</summary>
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/179.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/179.webp)
 
 Because A1 and J2 aren't real components - we only need their footprint and pin layout, not the component itself - they don't need an LCSC part number.
 </details>
@@ -85,21 +85,21 @@ Because A1 and J2 aren't real components - we only need their footprint and pin 
 
 Now, go back to the PCB view and sync it.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/110.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/110.webp)
 
 Then, click on Tools > External Plugins > Fabrication Toolkit.
 
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/211.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/211.webp)
 
 Everything you need to order your board will now be in `your_kicad_project/production/`.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/312.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/312.webp)
 
 Now, log in to [jlcpcb.com](https://jlcpcb.com). Go to [cart.jlcpcb.com/quote](https://cart.jlcpcb.com/quote) and upload `gerber.zip` into "Add Gerber file".
 
 You should see something like this:
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/413.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/413.webp)
 
 Tips:
 - 5 is the minimum number of PCBs you can order.
@@ -113,26 +113,26 @@ Leave the 'High-spec options' at their defaults, and then, enable assembly.
 - Standard PCB assembly with both sides is very expensive  (~$65) and will use up most of your grant money. Try to design PCBs that have components on one side and don't use any 'Standard Only' components. Or, solder the other side by hand.
 
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/514.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/514.webp)
 Then, on the Bill of Materials page, upload bom.csv and positions.csv from your production folder. 
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/716.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/716.webp)
 
 - You can save a lot of money on Extended Parts in the long run (if you plan on making many PCBs) by buying them directly and soldering them yourself [^1]. For example, basically every project has a USB-C connector and header pins, so it makes sense to buy a bunch yourself and avoid the $3 extended part fee every time you buy a board from JLCPCB.
 - Virtual Components (only used for their through holes) like the Arduino Nano and ICSP header can be ignored.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/817.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/817.webp)
 When it prompts you about unselected parts, just click 'Do not place'.
 
 Zoom into your components on the 'Component Placements' screen and rotate them to the correct orientation if they're wrong.
 
 If you get all parts assembled, this board (from part 2)[^4] ends up being around $33.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/918.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/918.webp)
 
 With shipping, that's $45 for me.
 
-![](https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/1019.webp)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-9ctvo6cbs-hack-club-bot.vercel.app/1019.webp)
 
 [^1]: You might want to edit the footprints of components you are hand-soldering. For example, to hand solder the USB-C connector, make the pads longer and remove unused ones like SBUS.
 [^2]: There are a million different ways to export your files and order with different manufacturers, but for simplicity, this jam only focuses on one.

--- a/jams/batches/sparkletilt-pcb/readMe/en-US.md
+++ b/jams/batches/sparkletilt-pcb/readMe/en-US.md
@@ -3,7 +3,7 @@ title: 'SparkleTilt: Design a Digital Level PCB'
 contributor: 'karmanyaahm'
 description: "Ever wondered how your phone knows when you tilt it? What makes an Arduino tick? With this jam, you'll level up your circuit skills by building your own Arduino-compatible level PCB! You can use it to measure angles, decorate your room, or do anything you can with an Arduino!"
 video: ''
-thumbnail: 'https://cloud-ibgx5zvea-hack-club-bot.vercel.app/00001__1__50_50.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-ibgx5zvea-hack-club-bot.vercel.app/00001__1__50_50.webp'
 keywords: 'PCB, KiCAD, electronics, schematic, Atmel, ATMega328P, Arduino, microcontroller, circuit'
 timeEstimate: '8 Hours' # ????? IDK
 difficulty: 'Advanced'

--- a/jams/batches/sprig/part-1/en-US.md
+++ b/jams/batches/sprig/part-1/en-US.md
@@ -6,14 +6,14 @@ description: >
     Get started making your very first game with the Sprig game engine! Even if you're a beginner, you'll walk out of this jam with your very own game in the Gallery.
 contributor: 'recursiveforte'
 contributorSlackId: 'U02UYFZQ0G0'
-thumbnail: 'https://cloud-injns3luf-hack-club-bot.vercel.app/0untitled.gif'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-injns3luf-hack-club-bot.vercel.app/0untitled.gif'
 timeEstimate: '45-60 Min'
 difficulty: 'Beginner'
 keywords: 'Sprig, Games, Game'
 language: 'JavaScript'
 presentation: "https://www.figma.com/file/mYayY1K4DjZxj8cGsWLdAC/Sprig-%231?type=design&node-id=236%3A2&mode=design&t=tBVyzkkMF86LCUGx-1" 
 presentationPlay: "https://www.figma.com/proto/mYayY1K4DjZxj8cGsWLdAC/Sprig-%231?page-id=236%3A2&type=design&node-id=236-1250&viewport=346%2C360%2C0.06&t=5XhFfrVWyRo8L9CB-1&scaling=contain&starting-point-node-id=236%3A1250&mode=design" 
-presentationPDF: "https://cloud-pxftj80n6-hack-club-bot.vercel.app/0sprig__1.pdf" 
+presentationPDF: "https://cdn.hackclub.com/rescue?url=https://cloud-pxftj80n6-hack-club-bot.vercel.app/0sprig__1.pdf" 
 notes: "" 
 poster: "https://github.com/hackclub/posters#:~:text=Author-,Download,-Download"
 video: ""
@@ -55,7 +55,7 @@ By completing your own game in Sprig, you'll also qualify to receive a [Sprig Co
 
 ## 2. Let’s explore the world of Sprig
 
-<video src="https://cloud-qrfzzm21i-hack-club-bot.vercel.app/0untitled.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-qrfzzm21i-hack-club-bot.vercel.app/0untitled.mp4" controls="controls" style={{maxWidth: "720px"}}></video>
 
 This video shows you around the world of sprig.
 
@@ -75,22 +75,22 @@ You'll want to register with Sprig to save your work! Otherwise, logging out of 
 
 In the login page, enter your email. A login code will be sent.
 
-![](https://cloud-2pdfjcqvn-hack-club-bot.vercel.app/0log_in___sprig.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-2pdfjcqvn-hack-club-bot.vercel.app/0log_in___sprig.png)
 
 Use the code sent to you to log in (can't find it... check spam folders?).
 
-![](https://cloud-hpv87yyem-hack-club-bot.vercel.app/0your_games___sprig.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-hpv87yyem-hack-club-bot.vercel.app/0your_games___sprig.png)
 
 Congrats! You’re now logged in. To access your saved games, use the same email to log in.
 
 ## 3. Build Your First Game!
 Click on the gallery up top.
 
-![](https://cloud-1f122cf0k-hack-club-bot.vercel.app/0gallery___sprig.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-1f122cf0k-hack-club-bot.vercel.app/0gallery___sprig.png)
 
 We’ll be following the getting_started tutorial. Click it.
 
-![](https://cloud-pcjfwllpn-hack-club-bot.vercel.app/0getting_started___sprig.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-pcjfwllpn-hack-club-bot.vercel.app/0getting_started___sprig.png)
 
 In the HELP screen there are both a TOOLKIT of functions particular to Sprig, and a TUTORIAL for “Getting_Started.” Follow the instructions there to build your first Sokobon Puzzle!
 
@@ -99,5 +99,5 @@ Click the "remix" button in the top right corner, so that your changes will be s
 ## 4. Wrap-up!
 Congratulations! By finishing this session, you just made your first game in Sprig!  
 
-![](https://cloud-4ja9fp00s-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-4ja9fp00s-hack-club-bot.vercel.app/0image.png)
 Next session and for the next 2 sessions, we’ll be building on our knowledge and creating a maze game from scratch. Click [here](/batch/sprig/part-2) to advance to the next session.

--- a/jams/batches/sprig/part-2/en-US.md
+++ b/jams/batches/sprig/part-2/en-US.md
@@ -6,14 +6,14 @@ description: >
     Get started making your very first game with the Sprig game engine! Even if you're a beginner, you'll walk out of this jam with your very own game in the Gallery.
 contributor: 'recursiveforte'
 contributorSlackId: 'U02UYFZQ0G0'
-thumbnail: 'https://cloud-ctbvwlpse-hack-club-bot.vercel.app/0sprig.gif'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-ctbvwlpse-hack-club-bot.vercel.app/0sprig.gif'
 timeEstimate: '45-60 Min'
 difficulty: 'Beginner'
 keywords: 'Sprig, Games, Game'
 language: 'JavaScript'
 presentation: "https://www.figma.com/file/Csn3pewJwcY5zk1mD8TnKS/Sprig-%232?type=design&node-id=236%3A2&mode=design&t=vsryibC09yq38LhW-1" 
 presentationPlay: "https://www.figma.com/proto/Csn3pewJwcY5zk1mD8TnKS/Sprig-%232?page-id=236%3A2&type=design&node-id=236-1250&viewport=884%2C360%2C0.15&t=Guxr4TgtI1gYXnGc-1&scaling=contain&starting-point-node-id=236%3A1250&mode=design" 
-presentationPDF: "https://cloud-9yb2ef0ar-hack-club-bot.vercel.app/0sprig__1.pdf" 
+presentationPDF: "https://cdn.hackclub.com/rescue?url=https://cloud-9yb2ef0ar-hack-club-bot.vercel.app/0sprig__1.pdf" 
 notes: "" 
 poster: "https://github.com/hackclub/posters#:~:text=Author-,Download,-Download"
 video: "" 
@@ -29,7 +29,7 @@ Here's some ideas to encourage this:
 ## Get Started
 Last session, you built a push block game in Sprig (if you haven't, check out [part 1](/batch/sprig/part-1) of this jam!). Let's build off that experience and make something even more awesome!
 
-![](https://cloud-ctbvwlpse-hack-club-bot.vercel.app/0sprig.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-ctbvwlpse-hack-club-bot.vercel.app/0sprig.gif)
 *This is a sample of what your base game might look like! I made mine about a watering can who needs to get to a flower, but your game's story, levels, sprites, etc. will be your very own :)*
 
 Today, we'll be learning to make a maze game in Sprig! By the end of this jam, you'll have created your very own maze game from scratch! Next session we'll be adding custom game mechanics and getting ready to share your game with the world! (how exciting is that??)
@@ -49,5 +49,5 @@ Let's head to [this page](https://sprig.hackclub.com/gallery/maze_game_starter) 
 ## Wrap-up!
 Congratulations!! By finishing this tutorial, you just made your own game from scratch!
 
-![](https://cloud-bsg8pyzmi-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_15.27.47.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-bsg8pyzmi-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_15.27.47.png)
 Next session, we'll be adding custom game mechanics to our game! Take a look at the game mechanics list in [part 3](/batch/sprig/part-3) for some examples of what you can make.

--- a/jams/batches/sprig/part-3/en-US.md
+++ b/jams/batches/sprig/part-3/en-US.md
@@ -6,14 +6,14 @@ description: >
   Get started making your very first game with the Sprig game engine! Even if you're a beginner, you'll walk out of this jam with your very own game in the Gallery.
 contributor: 'recursiveforte'
 contributorSlackId: 'U02UYFZQ0G0'
-thumbnail: 'https://cloud-mswaasys4-hack-club-bot.vercel.app/0screen_recording_2023-07-13_at_11.12.28.gif'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-mswaasys4-hack-club-bot.vercel.app/0screen_recording_2023-07-13_at_11.12.28.gif'
 timeEstimate: '100-120 Min'
 difficulty: 'Beginner'
 keywords: 'Sprig, Games, Game'
 language: 'JavaScript'
 presentation: "https://www.figma.com/file/9BNjIY4eHfIaCEtt5wDRem/Sprig-%232?type=design&node-id=236%3A1250&mode=design&t=fM4vMhLXBrrgOLgn-1" 
 presentationPlay: "https://www.figma.com/proto/9BNjIY4eHfIaCEtt5wDRem/Sprig-%232?page-id=236%3A2&type=design&node-id=236-1250&viewport=2326%2C360%2C0.42&t=n9VGx7fjXaaTsujH-1&scaling=contain&starting-point-node-id=236%3A1250&mode=design" 
-presentationPDF: "https://cloud-dhrlob55r-hack-club-bot.vercel.app/0sprig__2.pdf" 
+presentationPDF: "https://cdn.hackclub.com/rescue?url=https://cloud-dhrlob55r-hack-club-bot.vercel.app/0sprig__2.pdf" 
 notes: "" 
 poster: "https://github.com/hackclub/posters#:~:text=Author-,Download,-Download"
 video: "" 

--- a/jams/batches/sprig/part-4/en-US.md
+++ b/jams/batches/sprig/part-4/en-US.md
@@ -6,14 +6,14 @@ description: >
   Get started making your very first game with the Sprig game engine! Even if you're a beginner, you'll walk out of this jam with your very own game in the Gallery.
 contributor: 'recursiveforte'
 contributorSlackId: 'U02UYFZQ0G0'
-thumbnail: 'https://cloud-fqlz047vq-hack-club-bot.vercel.app/0gallery___sprig.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-fqlz047vq-hack-club-bot.vercel.app/0gallery___sprig.png'
 timeEstimate: '30 Min'
 difficulty: 'Beginner'
 keywords: 'Sprig, Games, Game'
 language: 'JavaScript'
 presentation: "https://www.figma.com/file/gJEGgAKoD7IWe3JlWvyuJy/Sprig-%233?type=design&node-id=236%3A2&mode=design&t=Ez3kER4gkG3rAgL0-1" 
 presentationPlay: "https://www.figma.com/proto/gJEGgAKoD7IWe3JlWvyuJy/Sprig-%233?page-id=236%3A2&type=design&node-id=236-1250&viewport=2143%2C158%2C0.35&t=d9Q4jIUUi28MgvvL-1&scaling=contain&starting-point-node-id=236%3A1250&mode=design" 
-presentationPDF: "https://cloud-ml1q5gsx1-hack-club-bot.vercel.app/0sprig__3.pdf" 
+presentationPDF: "https://cdn.hackclub.com/rescue?url=https://cloud-ml1q5gsx1-hack-club-bot.vercel.app/0sprig__3.pdf" 
 notes: "" 
 poster: "https://github.com/hackclub/posters#:~:text=Author-,Download,-Download"
 video: "" 

--- a/jams/batches/sprig/readMe/en-US.md
+++ b/jams/batches/sprig/readMe/en-US.md
@@ -4,12 +4,12 @@ contributor: 'recursiveforte'
 contributorSlackId: 'U02UYFZQ0G0'
 description: "Get started making your very first game with the Sprig game engine, using JavaScript! Sprig is a great tool for both beginners and advanced programmers, and if you make a game, you can get a free DIY handheld console! Follow this four-part series in order, and you'll get to make your very own puzzle game."
 video: 'none'
-thumbnail: 'https://cloud-q46uaypfr-hack-club-bot.vercel.app/00003__1_-2.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-q46uaypfr-hack-club-bot.vercel.app/00003__1_-2.webp'
 keywords: 'Game, Sprig, Games'
 timeEstimate: '5 Hours'
 difficulty: 'Beginner'
 slug: 'sprig'
 short: 'Get started making games with Sprig!'
-sticker: 'https://cloud-gdkvjap51-hack-club-bot.vercel.app/0000frame_100__1_-2.webp'
+sticker: 'https://cdn.hackclub.com/rescue?url=https://cloud-gdkvjap51-hack-club-bot.vercel.app/0000frame_100__1_-2.webp'
 isBatch: True
 ---

--- a/jams/batches/usb-hub/part-1/en-US.md
+++ b/jams/batches/usb-hub/part-1/en-US.md
@@ -6,7 +6,7 @@ description: >
     Get started making your schematic for your very own USB hub! Even if you're a beginner, you'll walk out of this jam with your very own schematic.
 contributor: 'MaxWofford'
 contributorSlackID: 'U0C7B14Q3'
-thumbnail: 'https://cloud-d5i0seddy-hack-club-bot.vercel.app/1usb_hub_jam_part_1_thumbnail.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-d5i0seddy-hack-club-bot.vercel.app/1usb_hub_jam_part_1_thumbnail.png'
 timeEstimate: '45-60 Min'
 difficulty: 'Intermediate'
 keywords: 'PCB, Circuit, PCB, Hub, Electronics, Schematic, Design, EasyEDA, EDA, Beginner'
@@ -19,11 +19,11 @@ video: ""
 totalParts: 2
 ---
 
-_Want to just see the result? See the [Schematic](https://cloud-1we5i4we0-hack-club-bot.vercel.app/1schematic_schematic-usb-hub-2-port-jam_2023-08-10.pdf) and the [EasyEDA source](https://cloud-1we5i4we0-hack-club-bot.vercel.app/0sch_schematic-usb-hub-2-port-jam_2023-08-10.json)._
+_Want to just see the result? See the [Schematic](https://cdn.hackclub.com/rescue?url=https://cloud-1we5i4we0-hack-club-bot.vercel.app/1schematic_schematic-usb-hub-2-port-jam_2023-08-10.pdf) and the [EasyEDA source](https://cdn.hackclub.com/rescue?url=https://cloud-1we5i4we0-hack-club-bot.vercel.app/0sch_schematic-usb-hub-2-port-jam_2023-08-10.json)._
 
 # Putting the "scheme" in schematic
 
-![](https://cloud-j8bxr01tm-hack-club-bot.vercel.app/1usb_hub_needed.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-j8bxr01tm-hack-club-bot.vercel.app/1usb_hub_needed.png)
 
 _Has this ever happened to you? You really need a USB hub!_
 
@@ -31,7 +31,7 @@ Today we're going to make a USB splitter. It'll have 1 USB-A on one side, and 2 
 
 We're starting with a schematic. They're like the blueprint for a PCB. It's a good way to figure out what's connected to what before you actually lay out the parts on your board.
 
-![](https://cloud-6d6aarot8-hack-club-bot.vercel.app/0schematic_to_pcb.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-6d6aarot8-hack-club-bot.vercel.app/0schematic_to_pcb.png)
 
 > Schematics correspond to the parts of your PCB.
 
@@ -47,7 +47,7 @@ For our design, we're going to need a USB-A connector that plugs into our comput
 
 Once you select it, click the `Place` button to add the part to our project. It might look a little different than the images in this tutorial, but that's okay.
 
-![](https://cloud-b1al1d09c-hack-club-bot.vercel.app/00screenshot_2023-08-08_at_12.20.04.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-b1al1d09c-hack-club-bot.vercel.app/00screenshot_2023-08-08_at_12.20.04.png)
 
 Yeah! You did it. Now let's add the other parts we'll need!
 
@@ -70,15 +70,15 @@ Let's find the spec for the CoreChips SL2.1A. A spec is kinda like a README for 
 
 Go to [lcsc.com](https://lcsc.com) and search for `C192893`. Click on the part and scroll down to the `Datasheet` section. Click on the link to download the datasheet.
 
-_Just in case, [here's a link to the spec sheet for the SL2.1A](https://cloud-fa5e1sjdd-hack-club-bot.vercel.app/01811151645_corechips-sl2-1a_c192893.pdf)._
+_Just in case, [here's a link to the spec sheet for the SL2.1A](https://cdn.hackclub.com/rescue?url=https://cloud-fa5e1sjdd-hack-club-bot.vercel.app/01811151645_corechips-sl2-1a_c192893.pdf)._
 
 Now let's open it up and just start reading through the table of contents to find where <i>whoops</i> wait it's all in Chinese.
 
-![](https://cloud-961a0s7fx-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_19.05.22.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-961a0s7fx-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_19.05.22.png)
 
 That's fine! Many specs are in other languages and guessing/translating is part of the skill! The important part is in here, the list of pins and what they do. It looks like this:
 
-![](https://cloud-h587v4g5f-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_12.37.30.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-h587v4g5f-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_12.37.30.png)
 
 Printed Circuit Board (PCB) part-makers really like to use acronymns, which are the same in every language! We can use the acronymns to figure out what the pins do. Here's a list of the ones we'll need:
 
@@ -95,45 +95,45 @@ The part I chose also had a spec in chinese, but it's a common part so I found [
 
 Move the parts around so they're facing eachother (you can rotate them with the `R` key), the go ahead and connect `GND` on the usb to `GND` on the chip.
 
-![](https://cloud-ntdzh89kj-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_12.48.41.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-ntdzh89kj-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_12.48.41.png)
 
 Now you can connect `VCC` on the usb to `VDD5` on the chip. They aren't labelled the same thing, but `VCC` just means a voltage source, and USB-A is a 5V source.
 
 Next up, connect `D+` on the usb to `DP` on the chip, and `D-` on the usb to `DM` on the chip.
 
-![](https://cloud-72qwemi78-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_12.54.13.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-72qwemi78-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_12.54.13.png)
 
 Hmmmm, this is looking a little like a bowl of spaghetti. Let's clean it up with nets!
 
-![](https://cloud-j8bxr01tm-hack-club-bot.vercel.app/2spaghetti.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-j8bxr01tm-hack-club-bot.vercel.app/2spaghetti.png)
 
 ### Nets
 
 Nets are a way to group together wires that are connected to eachother. They're a great way to make your schematic look cleaner and easier to read. Go ahead and remove the VCC & GND lines, then choose the GND net from the toolbar on the right.
 
-![](https://cloud-m5x117vsl-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_12.56.40.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-m5x117vsl-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_12.56.40.png)
 
 Connect the GND net to the GND pins on the USB-A and the CoreChips SL2.1A. See how clean that new wiring is?
 
-![](https://cloud-7pzslk6qe-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_13.04.24.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-7pzslk6qe-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_13.04.24.png)
 
 Nets are kinda like portals– you can connect them from a distance as a way to keep from crossing your wires on your schematic. They're also good for connecting lots of things together– we're going to need to wire a lot of things to `GND` in a sec, and nets are a great way to do that.
 
 Keep in mind though with nets, there are a lot of ways to write things. All the following are a way to say PIN 4 and PIN 5 are connected to `GND`:
 
-![](https://cloud-d47mlqyh7-hack-club-bot.vercel.app/0gnd_net_types.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-d47mlqyh7-hack-club-bot.vercel.app/0gnd_net_types.png)
 
 To prevent mistakes, try to keep your nets looking like mine for this tutorial, but in general everyone has their own style and that's ok.
 
-![](https://cloud-j8bxr01tm-hack-club-bot.vercel.app/0gnd_nets.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-j8bxr01tm-hack-club-bot.vercel.app/0gnd_nets.png)
 
 ## Ground the Shield
 
 Go ahead and connect MH1 & MH2 to GND also. These aren't really ports- they're just the parts where the metal cover of the USB sticks into the board. We'll connect them to ground in case there's any static electricity.
 
-![](https://cloud-7u8ahczmz-hack-club-bot.vercel.app/0screenshot_2023-10-11_at_13.27.24.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-7u8ahczmz-hack-club-bot.vercel.app/0screenshot_2023-10-11_at_13.27.24.png)
 
-![](https://cloud-1vlpmdjo8-hack-club-bot.vercel.app/0screenshot_2023-10-11_at_13.30.41.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-1vlpmdjo8-hack-club-bot.vercel.app/0screenshot_2023-10-11_at_13.30.41.png)
 
 ## Add the other USBs
 
@@ -143,7 +143,7 @@ I'll position my USB-A female ports and hook them up to the main chip's `DP` and
 
 On these USBs, ports 5 & 6 are the same as ports MH1 & MH2. They're just the metal shield, so we'll connect them to `GND` as well.
 
-![](https://cloud-6cwv1d324-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_15.16.16.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-6cwv1d324-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_15.16.16.png)
 
 _Remember, with nets you can connect from a distance!_
 
@@ -153,7 +153,7 @@ The design is almost complete, and in a perfect world it would work just fine. B
 
 Knowing where these protective components go can be an art and hotly debated on many stackoverflow forms. Fortunately, the spec sheets we're using contain some example circuits for us to use. Let's take a look at the CoreChips SL2.1A spec sheet again:
 
-![](https://cloud-a1u1u3jnb-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.32.45.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-a1u1u3jnb-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.32.45.png)
 
 _This is a little hard to see, so we'll go through it step by step. For now, just know we're getting the following instructions from reading this image & adapting it a little for our own design._
 
@@ -163,13 +163,13 @@ _Diodes ensure power flows in 1 direction. We don't want an accidental spike to 
 
 Now let's protect from power surges that make it past the diode. We'll use a capacitor for this– it's kinda like a resevior for power. It can store up power and then release it when it's needed. If there's a power fluctuation, this capacitor will let the extra power blead out to `GND` harmlessly. We'll use a 10uF capacitor with part number [`C19702`](https://www.lcsc.com/product-detail/Multilayer-Ceramic-Capacitors-MLCC-SMD-SMT_Samsung-Electro-Mechanics-CL10A106KP8NNNC_C19702.html). Let's drop it in right after the diode, and connect it to `GND`.
 
-![](https://cloud-e0ekzo8gw-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.37.55.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-e0ekzo8gw-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.37.55.png)
 
 _When using a capacitor to prevent overflows like this it's called a ["decoupling capacitor"](https://components101.com/articles/decoupling-capacitor-vs-bypass-capacitors-working-and-applications). I'll admit I don't 100% understand why, but this won't short 5V to GND._
 
 Go ahead and use the same capacitors to protect the other USB-A ports. You can copy & paste the components, and then move them into place.
 
-![](https://cloud-lr6vmvrrj-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.44.21.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lr6vmvrrj-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.44.21.png)
 
 ## Unused ports
 
@@ -177,27 +177,27 @@ The SL2.1A chip we're using supports up to 4 USB ports, but we're making a small
 
 _Making a 4-port USB hub is left as a challenge for you to do if you want to!_
 
-![](https://cloud-4sab6gwqz-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.51.45.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-4sab6gwqz-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.51.45.png)
 
 All finished should have pins connected to some label or wire, even if it's just a "no connection" symbol. Your PCB will error if you try to send it to the manufacturer with any pins unlabeled.
 
-![](https://cloud-me27qfpwb-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.51.54.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-me27qfpwb-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.51.54.png)
 
 Next up are pins `VDD33` and `VDD18`. Sometimes components will have these to provide lower voltages for their internal circuitry. We don't need to worry about them for this design, but the spec shows that we need to bleed off the power to `GND` using another 10uF capacitor.
 
-![](https://cloud-p9cf2w5jg-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.58.13.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-p9cf2w5jg-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_17.58.13.png)
 
 Lastly, our chip provides clock circuitry through `XIN` and `XOUT` for advanced use if we wanted to overclock our USB ports. We aren't trying to do that, so we'll opt-out of it by connecting `XIN` to `GND` and marking `XOUT` as disconnected.
 
-![](https://cloud-np517gxwl-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_18.02.06.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-np517gxwl-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_18.02.06.png)
 
-Now, let's check if all the pins are connected. Try converting the schematic to a PCB. If you see a warning pop up that means a net is missing or not connected. ![](https://cloud-dmskkj3bl-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_18.36.08.png)
+Now, let's check if all the pins are connected. Try converting the schematic to a PCB. If you see a warning pop up that means a net is missing or not connected. ![](https://cdn.hackclub.com/rescue?url=https://cloud-dmskkj3bl-hack-club-bot.vercel.app/0screenshot_2023-08-08_at_18.36.08.png)
 
 ## Finished!
 
 If all the schematic is connected you've done it!
 
-![](https://cloud-4dr6xa7qz-hack-club-bot.vercel.app/0yay.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-4dr6xa7qz-hack-club-bot.vercel.app/0yay.gif)
 
    <Announcement
             copy="Now make your board"

--- a/jams/batches/usb-hub/part-2/en-US.md
+++ b/jams/batches/usb-hub/part-2/en-US.md
@@ -6,7 +6,7 @@ description: >
     Use a schematic to start building your own USB hub!
 contributor: 'MaxWofford'
 contributorSlackID: 'U0C7B14Q3'
-thumbnail: 'https://cloud-d5i0seddy-hack-club-bot.vercel.app/0usb_hub_jam_part_2_thumbnail.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-d5i0seddy-hack-club-bot.vercel.app/0usb_hub_jam_part_2_thumbnail.png'
 timeEstimate: '45-60 Min'
 difficulty: 'Intermediate'
 keywords: 'PCB, circuit, board, electrical components'
@@ -20,31 +20,31 @@ video: ""
 totalParts: 2
 ---
 
-_If you haven't built a schematic yet, do so in [part 1](/batch/usb-hub/part-1). Just in case you can start with the [Schematic](https://cloud-1we5i4we0-hack-club-bot.vercel.app/1schematic_schematic-usb-hub-2-port-jam_2023-08-10.pdf) and the [EasyEDA source](https://cloud-1we5i4we0-hack-club-bot.vercel.app/0sch_schematic-usb-hub-2-port-jam_2023-08-10.json) we're starting with. Want to see the final result of this project? Here's a link to the final [EasyEDA Design](https://example.com)_
+_If you haven't built a schematic yet, do so in [part 1](/batch/usb-hub/part-1). Just in case you can start with the [Schematic](https://cdn.hackclub.com/rescue?url=https://cloud-1we5i4we0-hack-club-bot.vercel.app/1schematic_schematic-usb-hub-2-port-jam_2023-08-10.pdf) and the [EasyEDA source](https://cdn.hackclub.com/rescue?url=https://cloud-1we5i4we0-hack-club-bot.vercel.app/0sch_schematic-usb-hub-2-port-jam_2023-08-10.json) we're starting with. Want to see the final result of this project? Here's a link to the final [EasyEDA Design](https://example.com)_
 
 # Building the board!
 
 Now that we have our schematic, let's turn it into a board!
 
-Our starting schematic should look like this: ![](https://cloud-dtcbpm4i4-hack-club-bot.vercel.app/2screenshot_2023-08-11_at_12.52.40.png)
+Our starting schematic should look like this: ![](https://cdn.hackclub.com/rescue?url=https://cloud-dtcbpm4i4-hack-club-bot.vercel.app/2screenshot_2023-08-11_at_12.52.40.png)
 
-This is what we're going to make: ![](https://cloud-dtcbpm4i4-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.11.34.png)
+This is what we're going to make: ![](https://cdn.hackclub.com/rescue?url=https://cloud-dtcbpm4i4-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.11.34.png)
 
-Once it's ordered, it'll look like this: ![](https://cloud-dtcbpm4i4-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_13.11.20.png)
+Once it's ordered, it'll look like this: ![](https://cdn.hackclub.com/rescue?url=https://cloud-dtcbpm4i4-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_13.11.20.png)
 
 ## Step 1: Convert the schematic to a board
 
 Click "Design > Convert to PCB" in the top right corner of EasyEDA. This will open up the board editor.
 
-![](https://cloud-6cbfcd1xm-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.15.22.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-6cbfcd1xm-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.15.22.png)
 
 Next, confirm all the settings are exactly the same as– JK! these settings don't matter, just hit "apply" and move on:
 
-![](https://cloud-8ie7yt1k6-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.14.34.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-8ie7yt1k6-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.14.34.png)
 
 We'll be confronted with our parts laying out in the editor kinda like when we started out with the schematic. We'll need to move them around to make them fit on the board.
 
-![](https://cloud-8ie7yt1k6-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_13.14.44.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-8ie7yt1k6-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_13.14.44.png)
 
 ## Step 2: Move the parts around
 
@@ -56,7 +56,7 @@ _This is generated from our schematic, and is why we built our schematic first! 
 
 I moved the parts around a bit and ended up with this. A few things still overlap, but for the most part the lines have a clear route:
 
-![](https://cloud-5c3t0a3re-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.20.04.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-5c3t0a3re-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.20.04.png)
 
 _Keep in mind you might need to rotate your parts. Go ahead and do it with the "R" key. You can also rotate by degrees in the "Rotation" field on the right toolbar._
 
@@ -70,23 +70,23 @@ Next up comes the fun part! Let's wire up our parts. This is more of an art than
 
 First I'll select the "Track" tool on the toolbar:
 
-![](https://cloud-ikeoztttt-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_13.26.54.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-ikeoztttt-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_13.26.54.png)
 
 I'm starting with the +5V trace in this example:
 
-![](https://cloud-ikeoztttt-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.27.39.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-ikeoztttt-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.27.39.png)
 
 Lastly, this wire is a little thin for us, so let's <b>embiggen</b> it. Too small and the wire might burn out, but too big and it's hard to fit all your wires. There are a whole set of tables online that you can use to figure out the right width, but I usually just go with 0.8mm for my traces at +5V.
 
-![](https://cloud-ikeoztttt-hack-club-bot.vercel.app/2screenshot_2023-08-11_at_13.27.10.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-ikeoztttt-hack-club-bot.vercel.app/2screenshot_2023-08-11_at_13.27.10.png)
 
-![](https://cloud-2dgv2s40z-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.31.56.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-2dgv2s40z-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.31.56.png)
 
 _Technically, you can add an extra "c" to "thicc" for every 0.4mm of width._
 
 Take your time and route the traces you can. Here's how far I got after a couple passes:
 
-![](https://cloud-l9gg41b78-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.38.20.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-l9gg41b78-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.38.20.png)
 
 Notice that the +5V traces are still ratlined. I couldn't connect them without overlapping other traces, so I've left them unrouted for now. There's also part of the `GND` line that isn't connected yet.
 
@@ -94,38 +94,38 @@ Notice that the +5V traces are still ratlined. I couldn't connect them without o
 
 Now we need more space to route our stuff! Let's break out our superpower– the other side of the board!
 
-![](https://cloud-559tio290-hack-club-bot.vercel.app/0ezgif.com-video-to-gif_1_.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-559tio290-hack-club-bot.vercel.app/0ezgif.com-video-to-gif_1_.gif)
 
 That's right- the other side of the board can have a trace too! Some boards are pancaked together and have 4, 6, even 16 layers of traces! We're not going to be that fancy with this though– we can get away with just 2 layers for this project. Good for simplicity and keeping our costs down.
 
 Let's use this tool to route the `D-` (for some reason showing up as `U3_9` in my screenshot) pin for the USB-A male.
 
-![](https://cloud-2421gzzt3-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.48.30.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-2421gzzt3-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.48.30.png)
 
 Add some traces to get the `U3_9` line as close as it can without overlapping anything.
 
-![](https://cloud-p4gld99aq-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.50.20.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-p4gld99aq-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.50.20.png)
 
 Switch to the "Via" tool and click the tip of the traces to add them to the tips. A "Via" is just a fancy way to say we're poking a whole through the board to the other side that's coated in copper so the current travels through it.
 
-![](https://cloud-loxykkofo-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.50.39.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-loxykkofo-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.50.39.png)
 
-![](https://cloud-cbdjno25j-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.51.55.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-cbdjno25j-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.51.55.png)
 
 To switch to the other side of the board, click the "edit" icon next to "BottomLayer" on the layer toolbar. It should look like a pencil
 
-![](https://cloud-n59r7hpq4-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_13.46.16.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-n59r7hpq4-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_13.46.16.png)
 
 Now we can route our traces on the bottom layer. Go ahead and connect the 2 vias we just made:
 
-![](https://cloud-8juvc3e6w-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.56.55.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-8juvc3e6w-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_13.56.55.png)
 
 Nice! Now the ratline has disappeared- that means we're all done with those pins!
 
 Try doing the rest of them on your own before continuing. Or don't... I'm just text on a website, I can't stop you from scrolling down to see the finished version.
 
-![](https://cloud-isdsylawg-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_14.00.12.png)
-![](https://cloud-isdsylawg-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_14.00.24.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-isdsylawg-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_14.00.12.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-isdsylawg-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_14.00.24.png)
 
 _I had to add some more traces on the "TopLayer" to get all my "BackLayer" pins to connect._
 
@@ -133,11 +133,11 @@ _I had to add some more traces on the "TopLayer" to get all my "BackLayer" pins 
 
 Next up we'll need to cut out our board and give it a shape! We'll use the "BoardOutline" layer to do this. Weirdly enough, we'll still be using the route tool like before.
 
-![](https://cloud-pxqhij3q1-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_14.02.31.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-pxqhij3q1-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_14.02.31.png)
 
 _You might already have a pink rectangle lying around from when you first imported your board from your schematic. Go ahead and delete that, we're making our own outline. A better outline!_
 
-![](https://cloud-dmke8w78v-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_14.06.12.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-dmke8w78v-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_14.06.12.png)
 
 
 If your male USB port has a pink line in the footprint, make sure it's **outside** of the board outline. Some USB ports are "sink components," which means that they go below the board. This makes sure to give them ample room.
@@ -151,12 +151,12 @@ I made my trace look like this, but yours can look different! Just make sure tha
 
 Also, don't forget to even out your corners!
 
-![](https://cloud-dmke8w78v-hack-club-bot.vercel.app/0ezgif.com-video-to-gif_2_.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-dmke8w78v-hack-club-bot.vercel.app/0ezgif.com-video-to-gif_2_.gif)
 
 Now that we have the borders cut out, let's see the results! Click "View > 3D View" in the top toolbar.
 
-![](https://cloud-kcfrggbze-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_14.10.51.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-kcfrggbze-hack-club-bot.vercel.app/0screenshot_2023-08-11_at_14.10.51.png)
 
-![](https://cloud-kcfrggbze-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_14.11.06.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-kcfrggbze-hack-club-bot.vercel.app/1screenshot_2023-08-11_at_14.11.06.png)
 
 Done! That's it. You don't have to go home, but you can't stay here.

--- a/jams/batches/usb-hub/readMe/en-US.md
+++ b/jams/batches/usb-hub/readMe/en-US.md
@@ -3,7 +3,7 @@ title: 'Build a USB Hub'
 contributor: 'maxwofford'
 description: "Ever have a keyboard, mouse, and more to plug in but only one free USB port to use? You probably fixed it with a USB hub– but how do they work? In this jam you'll build your own from scratch."
 video: ''
-thumbnail: 'https://cloud-7x19y609v-hack-club-bot.vercel.app/0usb_hub_jam_thumbnail.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-7x19y609v-hack-club-bot.vercel.app/0usb_hub_jam_thumbnail.png'
 keywords: 'PCB, Circuit, USB, PCB, Hub, Electronics, Soldering, Schematic, Design, EasyEDA, EDA, Beginner'
 timeEstimate: '2 Hours'
 difficulty: 'Intermediate'

--- a/jams/batches/webOS/part-1/el-GR.md
+++ b/jams/batches/webOS/part-1/el-GR.md
@@ -9,14 +9,14 @@ description: >
   το οποίο θα είναι η βάση για τα υπόλοιπα Jams.
 contributor: SerenityUX
 contributorSlackID: 'U041FQB8VK2'
-thumbnail: 'https://cloud-78mhgjste-hack-club-bot.vercel.app/0welcomescreen.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-78mhgjste-hack-club-bot.vercel.app/0welcomescreen.png'
 timeEstimate: '30 Min'
 difficulty: Intermediate
 keywords: 'Web, os, personalOS, webOS, website, javascript, html, css, replit'
 language: 'HTML & CSS'
 presentation: 'https://www.figma.com/file/GKrLB0EfGWDcErrbrO1Wre/webOSPart1?type=design&node-id=0%3A1&mode=design&t=0HHMIeSDMmAzH864-1'
 presentationPlay: 'https://www.figma.com/proto/GKrLB0EfGWDcErrbrO1Wre/webOSPart1?page-id=0%3A1&type=design&node-id=1-14&viewport=-22828%2C193%2C0.29&t=Zv6vemAJ3hYlLn6Q-1&scaling=contain&starting-point-node-id=1%3A2&mode=design'
-presentationPDF: 'https://cloud-esbedol6s-hack-club-bot.vercel.app/20webospart1-min.pdf'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-esbedol6s-hack-club-bot.vercel.app/20webospart1-min.pdf'
 notes: ''
 poster: ''
 video: ''
@@ -24,7 +24,7 @@ totalParts: 5
 ---
 <div style={{"font-family": "Helvetica, Noto Sans, sans-serif"}}>
 
-![Capybara OS demo](https://cloud-ir4w2s05f-hack-club-bot.vercel.app/0screenrecording.gif)
+![Capybara OS demo](https://cdn.hackclub.com/rescue?url=https://cloud-ir4w2s05f-hack-club-bot.vercel.app/0screenrecording.gif)
 [Live Demo ](https://step8.thomasstubblef2.repl.co/) &
 [Sample Code](https://replit.com/@ThomasStubblef2/Step8#index.html)
 
@@ -36,7 +36,7 @@ totalParts: 5
 Θα είναι πολύ διασκεδαστικό και θα έχεις ένα μοναδικό και πολύ ωραίο αποτέλεσμα
 το οποίο θα είναι η βάση για τα υπόλοιπα Jams.**
 
-![εδώ είναι το πως μπορεί να φαίνεται το αποτέλεσμα](https://cloud-nzaoewszc-hack-club-bot.vercel.app/0screenshot_2023-07-23_at_2.31.58_pm.png)
+![εδώ είναι το πως μπορεί να φαίνεται το αποτέλεσμα](https://cdn.hackclub.com/rescue?url=https://cloud-nzaoewszc-hack-club-bot.vercel.app/0screenshot_2023-07-23_at_2.31.58_pm.png)
 
 Υπάρχουν 6 βήματα σε αυτό το Jam! Ακολούθησε το κάθε ένα και άρχισε να φτιάχνεις.
 
@@ -72,7 +72,7 @@ totalParts: 5
 
 Το Replit θα σε ετοιμάσει έναν έτοιμο κώδικα για να αρχίσεις.
 
-![Replit-Signup](https://cloud-c6z75ah46-hack-club-bot.vercel.app/0export_jun_15_2023_0159_pm.gif)
+![Replit-Signup](https://cdn.hackclub.com/rescue?url=https://cloud-c6z75ah46-hack-club-bot.vercel.app/0export_jun_15_2023_0159_pm.gif)
 
 
 ## Χτίσε με Elements
@@ -80,21 +80,21 @@ totalParts: 5
 ### Τι είναι τα elements?
 Κάθε ιστοσελίδα που έχεις επισκεφθεί έχει elements (στοιχεία). Τα Elements είναι τα "τούβλα" που έχουμε για να δημιουργήσουμε ιστοσελίδες. Για παράδειγμα, αυτ το κομμάτι κειμένου είναι ένα element. Το gif που θα δεις παρακάτω είναι και αυτό ένα element. Μέχρι και το container που έχει το κείμενο που διαβάσεις είναι ένα element. Δοκίμασε να κάνεις δεξί κλικ σε αυτήν την ιστοσελίδα και να πατήσεις Inspect, θα δεις πολλά elements. Η HTML είναι ο τύπος αρχείου για αυτά τα elements.
 
-![Οθόνη Inspect](https://cloud-8ywcul7zm-hack-club-bot.vercel.app/0inspect.gif)
+![Οθόνη Inspect](https://cdn.hackclub.com/rescue?url=https://cloud-8ywcul7zm-hack-club-bot.vercel.app/0inspect.gif)
 
 #### Απο τι αποτελείτε ένα element;
 Τα Elements αποτελούνται από 3 μέρη.
 
 Τα Elements αποτελούνται απο ένα opening tag, το περιεχόμενο στη μέση, και ένα closing tag. Για παράδειγμα `<p>Sample Content</p>` δημιουργεί ένα κείμενο παραγράφου γιατί υπάρχει ένα opening tag (`<p>`), με περιεχόμενο στη μέση (`Sample Content`), και ένα closing tag (`</p>`) που δείχνει το τέλος του element.
 
-![κουλούρι](https://cloud-rd8lvcrjx-hack-club-bot.vercel.app/0video.gif)
+![κουλούρι](https://cdn.hackclub.com/rescue?url=https://cloud-rd8lvcrjx-hack-club-bot.vercel.app/0video.gif)
 *(κουλούρια μοιάζουν πολύ με tags ή μπορείς να πείς ότι τα tags μοιάζουν με κουλούρια… Όπως το δει κανείς)*
 
 ### Πού μπορώ να τα τοποθετήσω;
 
 Ας αρχίσουμε με το να διαγράψουμε τον αρχικό κώδικα που μας έδωσε το Replit
 
-![διέγραψε αρχικό κώδικα](https://cloud-884himjr3-hack-club-bot.vercel.app/0nameswitch.gif)
+![διέγραψε αρχικό κώδικα](https://cdn.hackclub.com/rescue?url=https://cloud-884himjr3-hack-club-bot.vercel.app/0nameswitch.gif)
 
 Ο δεινόσαυρος Orpheus *(μη ρωτήσεις ποιός είναι ο [Orpheus](https://workshops.hackclub.com/orpheus/) (Σημείωση του μεταφραστή: Μασκότ του Hack Club))* σο ζητάει να κάνεις αντιγραφή και επικόλληση τον κώδικα που ακολουθεί στο project σου
 
@@ -147,7 +147,7 @@ totalParts: 5
 Καλό το κείμενο, αλλά ας βάλουμε και μια εικόνα:
 Αρχικά, πρέπει να βάλουμε μια εικόνα μέσα στο Replit.
 
-![Βάλε την εικόνα σου μέσα στο Replit](https://cloud-id4r1tr7g-hack-club-bot.vercel.app/0drag_drop.gif)
+![Βάλε την εικόνα σου μέσα στο Replit](https://cdn.hackclub.com/rescue?url=https://cloud-id4r1tr7g-hack-club-bot.vercel.app/0drag_drop.gif)
 
 ```
 <body>
@@ -164,7 +164,7 @@ totalParts: 5
 
 Το image tag έχει το property `src` που σημαίνει source (δηλαδή πηγή) στα Αγγλικά. Μπορείς να βάλεις το link της εικόνας ή να τη βάλεις μέσα στο replit και να ορίσεις το src ως `"./imageName.png"`.
 
-![Ιστοσελίδα με κείμενο και μια εικόνα ενός Καγκιμπάρα](https://cloud-33eico6lp-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_11.54.32_am.png)
+![Ιστοσελίδα με κείμενο και μια εικόνα ενός Καγκιμπάρα](https://cdn.hackclub.com/rescue?url=https://cloud-33eico6lp-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_11.54.32_am.png)
 
 ### Ας κάνουμε ένα link σε μια άλλη σελίδα
 HTML (HyperText Markup Language στα Αγγλικά) δημιουργήθηκε απο επιστήμονες για να μεταδώσουν έγγραφα μελετών (και τώρα είναι σε κάθε ιστοσελίδα στο internet). Εάν ξέρεις κάτι για επιστήμονες, τότε ξέρεις ότι ΛΑΤΡΈΒΟΥΝ να κάνουν συνδέσεις σε άλλες σελίδες.
@@ -214,7 +214,7 @@ HTML (HyperText Markup Language στα Αγγλικά) δημιουργήθηκ�
 
 Το περιεχόμενό σου όμως μάλλον είναι μονότονο και αδιάφορο, το οποίο μας πάει στο επόμενο μας θέμα… Να δώσουμε στυλ στο περιεχόμενό μας!
 
-![στυλ περιεχομένου υπό κατασκευή](https://cloud-9jc9u3xyy-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_3.51.07_pm.png)
+![στυλ περιεχομένου υπό κατασκευή](https://cdn.hackclub.com/rescue?url=https://cloud-9jc9u3xyy-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_3.51.07_pm.png)
 
 ## Δώσε στυλ στα elements σου
 ### Τι είναι το στυλ;
@@ -253,7 +253,7 @@ HTML (HyperText Markup Language στα Αγγλικά) δημιουργήθηκ�
 
 Απλά πήγαινε στην εικόνα και βάλε το style property το οποίο ορίζει το width (πλάτος) και το height (μήκος):
 
-`<img style="width: 64px; height: 64px" src="https://cloud-pc8imajxj-hack-club-bot.vercel.app/1img_1181.jpg" />`
+`<img style="width: 64px; height: 64px" src="https://cdn.hackclub.com/rescue?url=https://cloud-pc8imajxj-hack-club-bot.vercel.app/1img_1181.jpg" />`
 
 Επέλεξα να έχω το μήκος και το πλάτος 64 pixels, αλλά δε χρειάζεται να κάνεις το ίδιο! Διάλεξε το δικό σου μέγεθος, πειραματίσου, και διασκέδασε!
 
@@ -263,7 +263,7 @@ HTML (HyperText Markup Language στα Αγγλικά) δημιουργήθηκ�
 ##### *\*Παραλλαγμένη εικόνα*\*
 Η εικόνα σου μπορεί να είναι λίγο παραλλαγμένη (crunched up). Ψάξε στο Google πως να το φτιάξεις (μπορείς και να ρωτήσεις το ChatGPT). Μέχρι και μια απλή αναζήτηση, μάλλον θα δουλέψει.
 
-![crunched φωτογραφία](https://cloud-4cdvjzqmo-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_12.43.50_pm.png)
+![crunched φωτογραφία](https://cdn.hackclub.com/rescue?url=https://cloud-4cdvjzqmo-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_12.43.50_pm.png)
 
 <Dropdown title="Solution">
   Καθώς έψαχνα μεταξύ των αποτελεσμάτων στο Google, βρήκα το `object-fit: cover` property. Ας δοκιμάσουμε να το βάλουμε αυτό στη φωτογραφία μας. Α, τέλεια, η εικόνα μας διορθώθηκε. Όποτε κάτι φαίνεται άσχημο, ψάξτο στην Google και θα βρεις αποτελέσματα.
@@ -280,7 +280,7 @@ HTML (HyperText Markup Language στα Αγγλικά) δημιουργήθηκ�
 </Dropdown>
 
 
-![στρογγυλεμένη εικόνα](https://cloud-b43epg4q2-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_3.59.41_pm.png)
+![στρογγυλεμένη εικόνα](https://cdn.hackclub.com/rescue?url=https://cloud-b43epg4q2-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_3.59.41_pm.png)
 
 ### Στυλ γραμματοσειράς
 Το να αλλάξεις τη γραμματοσειρά στη CSS είναι εύκολο!
@@ -306,16 +306,16 @@ Padding είναι το κενό μεταξύ της εικόνας σου απ�
 
 Επιπλέον,… Υπάρχει ένα κομικό σκετσάκι από τον Shubham στο Epoch Bay Area για να μάθεις το Margin και Padding
 
-<video src="https://cloud-2jto14u7d-hack-club-bot.vercel.app/0vid_20221230_184903086.mp4" controls="controls" style={{maxWidth: "480px"}}>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-2jto14u7d-hack-club-bot.vercel.app/0vid_20221230_184903086.mp4" controls="controls" style={{maxWidth: "480px"}}>
 </video>
 
 Θα δούμε αυτό αργότερα, αλλά τώρα απλά θέλω να φέρω τα αντικείμενά μας ποιό κοντά.
 
-![spaced out](https://cloud-5txt6wpqn-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_4.12.11_pm.png)
+![spaced out](https://cdn.hackclub.com/rescue?url=https://cloud-5txt6wpqn-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_4.12.11_pm.png)
 
 Άρα αν ανοίξω το inspect…
 
-![Margin is the problem](https://cloud-p8iio5lh4-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_4.19.38_pm.png)
+![Margin is the problem](https://cdn.hackclub.com/rescue?url=https://cloud-p8iio5lh4-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_4.19.38_pm.png)
 
 Μπορούμε να δούμε ότι το προεπιλεγμένο margin στο h1 είναι αρκετά μεγάλο και κάνει τη σελίδα να φαίνεται κάπως περίεργα. Ας το διορθώσουμε.
 
@@ -334,7 +334,7 @@ Padding είναι το κενό μεταξύ της εικόνας σου απ�
 Δοκίμασε να βάλεις τα `background-color`, `color`, και `font-family` properties στο `body` tag για να κάνεις το site σου να φαίνεται όπως θες. Δεν είσαι σίγουρος πως να χρησιμοποιήσεις αυτά τα tags; Googlαρέ το!
 
 Εμένα έτσι μου βγήκε. Φτιάξε ότι σε κάνει να χαμογελάς! Αυτό είναι απλά το στυλ που χρησιμοποίησα εγώ.
-![πως βγήκε το δικό μου](https://cloud-nzaoewszc-hack-club-bot.vercel.app/0screenshot_2023-07-23_at_2.31.58_pm.png)
+![πως βγήκε το δικό μου](https://cdn.hackclub.com/rescue?url=https://cloud-nzaoewszc-hack-club-bot.vercel.app/0screenshot_2023-07-23_at_2.31.58_pm.png)
 
 
 
@@ -342,7 +342,7 @@ Padding είναι το κενό μεταξύ της εικόνας σου απ�
 
 Τέλεια! Εδώ είναι πως μου βγήκε εμένα. Ελπίζω το site σου να βγήκε τελείως διαφορετικά! Πάρε την ευκαιρία να κάνεις κάτι ωραίο με τη σελίδα σου!
 
-![Ολοκληρωμένη Ιστοσελίδα](https://cloud-423oznftn-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_4.27.35_pm.png)
+![Ολοκληρωμένη Ιστοσελίδα](https://cdn.hackclub.com/rescue?url=https://cloud-423oznftn-hack-club-bot.vercel.app/0screenshot_2023-06-16_at_4.27.35_pm.png)
 
 *Σημείωση: Μπορεί να είδες ότι έβαλα δικά μου tags μέσα στην παράγραφο, ΜΠΟΡΕΙΣ ΝΑ ΤΟ ΚΑΝΕΙΣ ΚΑΙ ΕΣΥ ΑΥΤΟ ΜΕ ΤΟ ΝΑ ΔΕΙΣ ΤΗΝ ΕΞΤΡΑ ΠΡΟΚΛΗΣΗ ΠΑΡΑΠΑΝΩ.*
 

--- a/jams/batches/webOS/part-1/en-US.md
+++ b/jams/batches/webOS/part-1/en-US.md
@@ -9,7 +9,7 @@ description: >
   that you'll build upon in subsequent Jams.
 contributor: SerenityUX
 contributorSlackID: 'U041FQB8VK2'
-thumbnail: 'https://cloud-78mhgjste-hack-club-bot.vercel.app/0welcomescreen.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-78mhgjste-hack-club-bot.vercel.app/0welcomescreen.png'
 timeEstimate: '30 Min'
 difficulty: Intermediate
 keywords: 'Web, os, personalOS, webOS, website, javascript, html, css, codespaces'

--- a/jams/batches/webOS/part-2/el-GR.md
+++ b/jams/batches/webOS/part-2/el-GR.md
@@ -8,14 +8,14 @@ description: >
   το οποίο θα είναι η βάση για τα υπόλοιπα Jams.
 contributor: SerenityUX
 contributorSlackID: 'U041FQB8VK2'
-thumbnail: 'https://cloud-1j1hqciuo-hack-club-bot.vercel.app/0desktopadded.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-1j1hqciuo-hack-club-bot.vercel.app/0desktopadded.png'
 timeEstimate: '30 Min'
 difficulty: Intermediate
 keywords: 'Web, os, personalOS, webOS, website, javascript, html, css, replit'
 language: 'HTML & CSS'
 presentation: 'https://www.figma.com/file/PTWgxtPTUU5ZdEr8JZtH7X/webOSPart2?type=design&node-id=0%3A1&mode=design&t=BUR8qjk3lvlcygxO-1'
 presentationPlay: 'https://www.figma.com/proto/PTWgxtPTUU5ZdEr8JZtH7X/webOSPart2?page-id=0%3A1&type=design&node-id=1-2&viewport=-21176%2C281%2C0.38&t=CSTNNjzGHDS0y5ls-1&scaling=contain&starting-point-node-id=1%3A2&mode=design'
-presentationPDF: 'https://cloud-esbedol6s-hack-club-bot.vercel.app/10webospart2-min.pdf'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-esbedol6s-hack-club-bot.vercel.app/10webospart2-min.pdf'
 notes: ''
 poster: ''
 video: ''
@@ -27,7 +27,7 @@ totalParts: 5
 
 Θα προσθέσεις το περίγραμμα των παραθύρων σου, θα δημιουργήσεις την επιφάνεια εργασίας σου και θα προσθέσεις μια πάνω μπάρα.
 
-![Θα τελειώσεις με](https://cloud-d6rlms9ox-hack-club-bot.vercel.app/0image.png)
+![Θα τελειώσεις με](https://cdn.hackclub.com/rescue?url=https://cloud-d6rlms9ox-hack-club-bot.vercel.app/0image.png)
 
 Παρ'όλο που θα γράψουμε Javascript, όλος ο κώδικας θα μείνει στο αρχείο της HTML *(μέχρι την επόμενη φορά)*
 
@@ -39,7 +39,7 @@ totalParts: 5
 ## Ορισμός του "παραθύρου"
 Λοιπόν, την τελευταία φορά τελείωσες με την αρχή της οθόνης καλωσορίσματος σου. Ας ελπίσουμε ότι δε θα μοιάζει καθόλου με το δικό μου. Ως υπενθύμιση, εδώ είναι πώς έμοιαζε το δικό μου:
 
-![Το παράθυρο](https://cloud-p1jqe7wd2-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_1.24.32_pm.png)
+![Το παράθυρο](https://cdn.hackclub.com/rescue?url=https://cloud-p1jqe7wd2-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_1.24.32_pm.png)
 
 ### Τι είναι ένα παράθυρο;
 Ένα παράθυρο είναι ένα πλαίσιο που ορίζει πού αρχίζει και πού τελειώνει μια εφαρμογή στο User Interface (UI) σου. Υποθέτω ότι ένα div θα μπορούσε να έχει οποιοδήποτε σχήμα (αν θέλεις τα παράθυρά σου να είναι κύκλοι, κάντο!).
@@ -48,7 +48,7 @@ totalParts: 5
 
 Τα τοιχώματα στο εσωτερικό του πλαισίου ορίζουν πού αρχίζει και πού τελειώνει το περιεχόμενο (νόστιμο φαγητό) και τα τοιχώματα κατά μήκος της άκρης του πλαισίου ορίζουν πού αρχίζει και πού τελειώνει το πλαίσιο.
 
-![Bento Box of Divs](https://cloud-e63a9spt4-hack-club-bot.vercel.app/0divbento.png)
+![Bento Box of Divs](https://cdn.hackclub.com/rescue?url=https://cloud-e63a9spt4-hack-club-bot.vercel.app/0divbento.png)
 
 ### Γιατί χρειαζόμαστε ένα παράθυρο;
 Η ύπαρξη πολλαπλών παραθύρων θα σου επιτρέψει να κάνεις τους χρήστες να αισθάνονται ότι έχουν τον έλεγχο της εμπειρίας τους (επιλέγοντας ποια παράθυρα θα ανοίξουν και σε ποια θα εστιάσουν και ποια θα αγνοήσουν) και θα παρέχει μια νέα/διασκεδαστική εμπειρία.
@@ -70,7 +70,7 @@ totalParts: 5
 
 Ωραία... Λοιπόν, η ιστοσελίδα σου ελπίζω να φαίνεται η ίδια και μπορεί να σκέφτεσαι ότι έκανες κάτι λάθος.
 
-![grouped in a div](https://cloud-czlk8j3wo-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_1.57.38_pm.png)
+![grouped in a div](https://cdn.hackclub.com/rescue?url=https://cloud-czlk8j3wo-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_1.57.38_pm.png)
 
 Μη φοβάσαι, είσαι στο σωστό δρόμο. Η ομάδα δεν έχει χαρακτηριστικά στυλ που θα την έκαναν οπτικά διακριτή από την υπόλοιπη σελίδα **ακόμη**.
 
@@ -85,7 +85,7 @@ totalParts: 5
 
 Απλό! Τώρα μπορούμε να δούμε ότι περιγράψαμε το περιεχόμενό μας.
 
-![stroke added](https://cloud-cn54hr3si-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_2.04.50_pm.png)
+![stroke added](https://cdn.hackclub.com/rescue?url=https://cloud-cn54hr3si-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_2.04.50_pm.png)
 
 *Έι... θέλεις να διασκεδάσεις; Επισκεφτείτε [αυτή την ιστοσελίδα](https://developer.mozilla.org/en-US/docs/Web/CSS/border) και δοκιμάστε να προσθέσετε μερικά ωραία εφέ (+ επίσης το δικό σου πλάτος και χρώμα)*.
 
@@ -111,7 +111,7 @@ totalParts: 5
 
 Επέλεξα 16px, αλλά μπορείς επίσης να το κάνεις πολύ πιο στρογγυλό αυξάνοντας αυτόν τον αριθμό! Πειραματίσου!
 
-![image of it without space](https://cloud-25a3olvni-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_2.21.27_pm.png)
+![image of it without space](https://cdn.hackclub.com/rescue?url=https://cloud-25a3olvni-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_2.21.27_pm.png)
 
 ΤΟ ΚΕΊΜΕΝΟ ΕΊΝΑΙ ΠΟΛΎ *ΚΛΑΣΤΡΟΦΟΒΙΚΌ*. ΤΟ ΒΆΖΕΙΣ ΣΕ ΈΝΑ ΚΟΥΤΊ ΚΑΙ ΔΕΝ ΈΧΕΙ ΚΑΘΌΛΟΥ ΧΏΡΟ ΓΙΑ ΝΑ ΑΝΑΠΝΕΎΣΕΙ!
 
@@ -143,7 +143,7 @@ totalParts: 5
 
 Και με την ιδιότητα `position: absolute`, ξεκλειδώνουμε τέσσερις ακόμα ιδιότητες (πάνω, κάτω, αριστερά, δεξιά). Κάθε μία ορίζει την απόσταση που θα έχει το παράθυρό μας από τα άκρα της οθόνης.
 
-![This is the screen](https://cloud-rn4u95i7l-hack-club-bot.vercel.app/0thisisthescreen.gif)
+![This is the screen](https://cdn.hackclub.com/rescue?url=https://cloud-rn4u95i7l-hack-club-bot.vercel.app/0thisisthescreen.gif)
 
 Για να το τοποθετήσουμε στο κέντρο, μπορούμε απλά να γράψουμε
 
@@ -162,13 +162,13 @@ transform: translate(-50%, -50%); (additional styles)">
     </div>
 ```
 
-![Image centered correctly](https://cloud-d0am8h8gg-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_2.42.10_pm.png)
+![Image centered correctly](https://cdn.hackclub.com/rescue?url=https://cloud-d0am8h8gg-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_2.42.10_pm.png)
 
 Εντάξει, αυτό φαίνεται υπέροχο.
 
 Ίσως είναι μια καλή στιγμή για να κάνεις ένα διάλειμμα για τέντωμα. Έχεις κάνει πολύ προγραμματισμό και η ιστοσελίδα σου είναι πανέμορφη!
 
-![Break](https://cloud-5gpc0802p-hack-club-bot.vercel.app/0ezgif-2-da8e476e69.gif)
+![Break](https://cdn.hackclub.com/rescue?url=https://cloud-5gpc0802p-hack-club-bot.vercel.app/0ezgif-2-da8e476e69.gif)
 
 ## Σχεδιάζοντας την επιφάνεια εργασίας μας
 Γύρισες πίσω. Είσαι ανανεωμένος. Ίσως να έφαγες και μια ή δύο φράουλες...
@@ -190,7 +190,7 @@ transform: translate(-50%, -50%); (additional styles)">
 
 Ας προσθέσουμε ένα χρώμα φόντου στο παράθυρό μας, ώστε να φαίνεται διακριτό από την επιφάνεια εργασίας.
 
-![background color added](https://cloud-4xp54hvar-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_3.31.34_pm.png)
+![background color added](https://cdn.hackclub.com/rescue?url=https://cloud-4xp54hvar-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_3.31.34_pm.png)
 
 ## Δημιουργία του Top Bar
 Μια επάνω μπάρα χρησιμοποιείται γενικά για να εμφανίζει το όνομα του λειτουργικού συστήματος, τις βασικές λειτουργίες μιας επιλεγμένης εφαρμογής και την ώρα. Μπορείς να επιλέξεις να εμφανίζεις όλες ή καμία από αυτές τις πληροφορίες. Μπορείς επίσης να αποφασίσεις να της δώσεις διαφορετικές λειτουργίες!
@@ -228,7 +228,7 @@ transform: translate(-50%, -50%); (additional styles)">
 
 Μπορούμε προαιρετικά να διαχωρίσουμε το περιεχόμενο εφαρμόζοντας το justify-content ( κοιτάξτε [αυτόν τον ιστότοπο δοκιμών justify-content](https://www.w3schools.com/cssref/playdemo.php?filename=playcss_justify-content) για να δεις πώς μπορείς να χρησιμοποιήσεις το justify-content για να διαχωρίσεις το περιεχόμενο)
 
-![justify-content](https://cloud-e3m7dz3v0-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_3.52.01_pm.png)
+![justify-content](https://cdn.hackclub.com/rescue?url=https://cloud-e3m7dz3v0-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_3.52.01_pm.png)
 με βάση αυτό το demo, αποφάσισα ότι θέλω να χρησιμοποιήσω το space-between στο παρακάτω παράδειγμα, αλλά σε συνιστώ να ελέγξεις την τοποθεσία δοκιμών και να διαλέξεις ποιο στυλ justify-content λειτουργεί καλύτερα για το σχέδιό σου!
 
 ```html
@@ -266,7 +266,7 @@ RGBA σημαίνει Red, Green, Blue, Alpha (Κόκκινο, Πράσινο, �
 
 Εδώ είναι πώς αποφάσισα να κάνω το δικό μου να φαίνεται
 
-![my top bar](https://cloud-5ozikpqtx-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_4.19.33_pm.png)
+![my top bar](https://cdn.hackclub.com/rescue?url=https://cloud-5ozikpqtx-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_4.19.33_pm.png)
 
 Ελπίζω το δικό σου να είναι τελείως διαφορετικό!
 Εδώ είναι ο κώδικάς μου σε περίπτωση που θέλεις να πάρεις έμπνευση από αυτόν. (αλλά και πάλι, ΜΗΝ ΚΑΝΕΙΣΤΕ ΑΚΡΙΒΗ ΑΝΤΙΓΡΑΦΗ)
@@ -319,7 +319,7 @@ RGBA σημαίνει Red, Green, Blue, Alpha (Κόκκινο, Πράσινο, �
 
 **Αυτή τη στιγμή θα γράψουμε τον κώδικά μας μέσα στο αρχείο HTML. Δεν θα αγγίξουμε ακόμα το αρχείο script.js *(μέχρι το επόμενο Jam)***
 
-![Write it in index.html](https://cloud-jajja5k48-hack-club-bot.vercel.app/0cat.png)
+![Write it in index.html](https://cdn.hackclub.com/rescue?url=https://cloud-jajja5k48-hack-club-bot.vercel.app/0cat.png)
 
 #### Πώς θα βρω το χρόνο;
 
@@ -378,7 +378,7 @@ new Date().toLocaleString(); είναι μια συνάρτηση του προ�
 </script>   
 ```
 
-![χρόνος που εμφανίζεται](https://cloud-rl0do8tyh-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_4.44.46_pm.png)
+![χρόνος που εμφανίζεται](https://cdn.hackclub.com/rescue?url=https://cloud-rl0do8tyh-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_4.44.46_pm.png)
 
 Τώρα έχουμε την τρέχουσα ώρα, αλλά μην βιαστείτε να πανηγυρίσετε. Θα προσέξεις ότι η ώρα δεν ενημερώνεται. Αυτό συμβαίνει επειδή ο κώδικας μέσα στην ετικέτα script εκτελείται μόνο μία φορά (όταν ανοίγει για πρώτη φορά η σελίδα).παρατηρήσετε
 
@@ -419,7 +419,7 @@ setInterval(function () {
 
 Τέλεια, να σε τι καταλήξαμε:
 
-![PersonalOS](https://cloud-r3drmd84c-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_4.59.32_pm.png)
+![PersonalOS](https://cdn.hackclub.com/rescue?url=https://cloud-r3drmd84c-hack-club-bot.vercel.app/0screenshot_2023-06-21_at_4.59.32_pm.png)
 
 Για την τελευταία πρόκληση μπόνους, δοκίμασε να προσθέσεις κάτι ενδιαφέρον στο φόντο σου. Ίσως να το κάνετε ένα gif;
 

--- a/jams/broken/discord-custom-message/en-US.md
+++ b/jams/broken/discord-custom-message/en-US.md
@@ -4,16 +4,16 @@ description: >
   In this Jam, we'll be working on creating stunning shapes and graphics using Python and its pre-installed Turtle library.
 contributor: 'zsh'
 originalAuthor: 'YashKalbande'
-thumbnail: 'https://cloud-36kk4uh0h.vercel.app/turtle_benzene_ring.gif'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-36kk4uh0h.vercel.app/turtle_benzene_ring.gif'
 timeEstimate: '45 Min'
 difficulty: 'Beginner'
 keywords: 'Beta, Python, Art'
 language: 'Python'
 presentation: 'https://www.figma.com/file/UFFlwD9kEFmMkygaY8yG3h/Untitled?type=design&node-id=0%3A1&mode=design&t=9UnEZB6EYxvg2aQv-1'
 presentationPlay: 'https://www.figma.com/proto/UFFlwD9kEFmMkygaY8yG3h/Untitled?type=design&node-id=2-2&t=IebotsxN9M6q3Edr-1&scaling=contain&page-id=0%3A1&mode=design'
-presentationPDF: 'https://cloud-fplorbj3h-hack-club-bot.vercel.app/0make_your_own_club_token_w_solidity.pdf'
-notes: 'https://cloud-mrmhmej0t-hack-club-bot.vercel.app/0notes_for_this_jam__for_learner_to_note__jot_down_.pdf'
-poster: 'https://cloud-5bv8lvd9u-hack-club-bot.vercel.app/0red_modern_and_minimalist_crypto_tips_your_story.png'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-fplorbj3h-hack-club-bot.vercel.app/0make_your_own_club_token_w_solidity.pdf'
+notes: 'https://cdn.hackclub.com/rescue?url=https://cloud-mrmhmej0t-hack-club-bot.vercel.app/0notes_for_this_jam__for_learner_to_note__jot_down_.pdf'
+poster: 'https://cdn.hackclub.com/rescue?url=https://cloud-5bv8lvd9u-hack-club-bot.vercel.app/0red_modern_and_minimalist_crypto_tips_your_story.png'
 video: ''
 slug: 'discord-custom-message'
 ---
@@ -24,7 +24,7 @@ description: >
   In this Jam, we're going to create a Discord bot that allows users to save custom messages that they can have the bot send at any time.
 contributor: 'zoya-hussain'
 originalAuthor: 'wollygfx'
-thumbnail: 'https://cloud-bj4vorj8t.vercel.app/examplebot.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-bj4vorj8t.vercel.app/examplebot.png'
 timeEstimate: '45 Min'
 difficulty: 'Intermediate'
 keywords: 'Beta'
@@ -40,7 +40,7 @@ slug: 'custom-discord-bot'
 
  Howdy! In this Jam, we're going to create a Discord bot that allows users to save custom messages that they can have the bot send at any time. By the end you will have programmed a sweet bot to add to your Discord server! Are you ready? Let's begin!
 
-<img src="https://cloud-bj4vorj8t.vercel.app/examplebot.png" width="380" alt="Message Example">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-bj4vorj8t.vercel.app/examplebot.png" width="380" alt="Message Example">
 
 ## Outline
 1. **Setup**: Establish the groundwork for your Discord bot project by setting up your bot, Repl.it, and JS file.
@@ -53,15 +53,15 @@ slug: 'custom-discord-bot'
 Let's set up a bot through Discord before creating its features! Click [here](https://discord.com/developers/applications).
 
 Click the "New Application" button at the top right.
-<img src="https://cloud-noinx6mnk.vercel.app/0screenshot__1379_.png" width="900" alt="New Application Button">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-noinx6mnk.vercel.app/0screenshot__1379_.png" width="900" alt="New Application Button">
 This creates a new bot where you can customize the name, description, and profile picture!
-<img src="https://cloud-jlzsnh85x.vercel.app/0screenshot__1380_.png" width="900" alt="Bot Profile">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-jlzsnh85x.vercel.app/0screenshot__1380_.png" width="900" alt="Bot Profile">
 
 Now click the "Bot" tab on the right side of your screen.
-<img src="https://cloud-e5r0obhgo.vercel.app/0screenshot__1381_.png" width="900" alt="Bot Side Bar">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-e5r0obhgo.vercel.app/0screenshot__1381_.png" width="900" alt="Bot Side Bar">
 
 Click "Add Bot" to generate a bot token. This identifies the bot. Give it to nobody!
-<img src="https://cloud-lix7k1shj.vercel.app/0screenshot__1382_.png" width="900" alt="Bot Token">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-lix7k1shj.vercel.app/0screenshot__1382_.png" width="900" alt="Bot Token">
 <img src="https://media4.giphy.com/media/pvl3qUsgblNOo/200.gif" width="380" alt="Zelda Gif">
 
 ## Repl.it Setup
@@ -70,11 +70,11 @@ We're going to use [Repl.it](https://repl.it/~) to host the bot. It is an online
 
 Create a new repl and use Node.js as the language.
 
-<img src="https://cloud-otu0relhe.vercel.app/0screenshot__1383_.png" width="600" alt="Node.js Repl">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-otu0relhe.vercel.app/0screenshot__1383_.png" width="600" alt="Node.js Repl">
 
 Make sure to set it to private. You'll be adding sensitive information to this project, so you don't want other people accessing your code.
 
-<img src="https://cloud-6u5f66efw.vercel.app/0screenshot__1418_.png" width="600" alt="Node.js Repl">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-6u5f66efw.vercel.app/0screenshot__1418_.png" width="600" alt="Node.js Repl">
 
 ## Initial Setup
 
@@ -90,7 +90,7 @@ JSON is a file format that allows you to store data as a JavaScript object (key/
 
 Once you create the `msgs.json` file, add two curly braces, like so:
 
-<img src="https://cloud-gh7l7h2q1.vercel.app/json_example.png" width="380" alt="Write Command Example">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-gh7l7h2q1.vercel.app/json_example.png" width="380" alt="Write Command Example">
 
 ### Writing JavaScript!
 
@@ -147,7 +147,7 @@ Yay! We've successfully completed our initial setup!
 
 Now let's start with a command that allows you to add your own custom messages. The user will provide a key that the message will be saved to and the message itself.
 
-<img src="https://cloud-kb9kganvz.vercel.app/write_message.png" width="380" alt="Write Command Example">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-kb9kganvz.vercel.app/write_message.png" width="380" alt="Write Command Example">
 
 We'll want the bot to respond to `!write {messageKey} {message}`.
 
@@ -246,7 +246,7 @@ Yay! The `!write` command is done!
 
 Now let's do the `!get` command. This allows you to get the message you saved!
 
-<img src="https://cloud-eing65rqs.vercel.app/get_message.png" width="380" alt="Get Command Example">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-eing65rqs.vercel.app/get_message.png" width="380" alt="Get Command Example">
 
 ```js
 client.on('message', (message) => {
@@ -272,7 +272,7 @@ As well, you can modify your `!get` command to allow for retrieving messages, sp
 
 Now, let's write a command to delete a message.
 
-<img src="https://cloud-uvlarb2g1.vercel.app/delete_message.png" width="380" alt="Delete Command Example">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-uvlarb2g1.vercel.app/delete_message.png" width="380" alt="Delete Command Example">
 
 ```js
 client.on('message', (message) => {
@@ -298,7 +298,7 @@ client.on('message', (message) => {
 
 Now let's allow the user to get the list of all their saved messages.
 
-<img src="https://cloud-2ghj25por.vercel.app/list_message.png" width="380" alt="List Command Example">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-2ghj25por.vercel.app/list_message.png" width="380" alt="List Command Example">
 
 ```js
 client.on('message', (message) => {
@@ -327,7 +327,7 @@ client.on('message', (message) => {
 
 Finally, let's create a help command that allows the user to see all the available commands.
 
-<img src="https://cloud-8qig9t4bs.vercel.app/help_message.png" width="380" alt="Help Command Example">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-8qig9t4bs.vercel.app/help_message.png" width="380" alt="Help Command Example">
 
 ```js
 client.on('message', (message) => {
@@ -408,7 +408,7 @@ Now that we've written all of the code, it's time to add this bot to your Discor
 
 Go [here](https://discordapi.com/permissions.html#).
 
-<img src="https://cloud-1ca9lqh0p.vercel.app/0screenshot__1384_.png" width="450" alt="Adding Bot to Your Server">
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-1ca9lqh0p.vercel.app/0screenshot__1384_.png" width="450" alt="Adding Bot to Your Server">
 
 Add your permissions, click the link at the bottom, and choose what server you want to add it to!
 

--- a/jams/broken/exciting-python-visuals/en-US.md
+++ b/jams/broken/exciting-python-visuals/en-US.md
@@ -4,23 +4,23 @@ description: >
   In this Jam, we'll be working on creating stunning shapes and graphics using Python and its pre-installed Turtle library.
 contributor: 'zsh'
 originalAuthor: 'YashKalbande'
-thumbnail: 'https://cloud-36kk4uh0h.vercel.app/turtle_benzene_ring.gif'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-36kk4uh0h.vercel.app/turtle_benzene_ring.gif'
 timeEstimate: '45 Min'
 difficulty: 'Beginner'
 keywords: 'Beta, Python, Art'
 language: 'Python'
 presentation: 'https://www.figma.com/file/UFFlwD9kEFmMkygaY8yG3h/Untitled?type=design&node-id=0%3A1&mode=design&t=9UnEZB6EYxvg2aQv-1'
 presentationPlay: 'https://www.figma.com/proto/UFFlwD9kEFmMkygaY8yG3h/Untitled?type=design&node-id=2-2&t=IebotsxN9M6q3Edr-1&scaling=contain&page-id=0%3A1&mode=design'
-presentationPDF: 'https://cloud-fplorbj3h-hack-club-bot.vercel.app/0make_your_own_club_token_w_solidity.pdf'
-notes: 'https://cloud-mrmhmej0t-hack-club-bot.vercel.app/0notes_for_this_jam__for_learner_to_note__jot_down_.pdf'
-poster: 'https://cloud-5bv8lvd9u-hack-club-bot.vercel.app/0red_modern_and_minimalist_crypto_tips_your_story.png'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-fplorbj3h-hack-club-bot.vercel.app/0make_your_own_club_token_w_solidity.pdf'
+notes: 'https://cdn.hackclub.com/rescue?url=https://cloud-mrmhmej0t-hack-club-bot.vercel.app/0notes_for_this_jam__for_learner_to_note__jot_down_.pdf'
+poster: 'https://cdn.hackclub.com/rescue?url=https://cloud-5bv8lvd9u-hack-club-bot.vercel.app/0red_modern_and_minimalist_crypto_tips_your_story.png'
 video: ''
 slug: 'exciting-python-visuals'
 ---
 
 Ahoy! In this Jam, we'll be working on creating stunning shapes and graphics using Python and its pre-installed Turtle library. Are you ready? Let's begin!
 
-![Benzen ring with Turtle](https://cloud-36kk4uh0h.vercel.app/turtle_benzene_ring.gif)
+![Benzen ring with Turtle](https://cdn.hackclub.com/rescue?url=https://cloud-36kk4uh0h.vercel.app/turtle_benzene_ring.gif)
 
 ## Outline
 1. **Hello, Turtle!:** An introduction to Turtle, Python's build in library that enables users to create pictures and shapes by providing them with a virtual canvas. Set up your environment and learn the basic methods for drawing.
@@ -79,7 +79,7 @@ forward(100)
 
 Click on Run Button. The output of this program will look like this:
 
-![Square](https://cloud-36kk4uh0h.vercel.app/square.gif)
+![Square](https://cdn.hackclub.com/rescue?url=https://cloud-36kk4uh0h.vercel.app/square.gif)
 
 The instructions in your program tell the "turtle" how to move. The turtle draws a line behind it as it moves. This program draws a square. The steps given to the program are:
 
@@ -230,7 +230,7 @@ pencil.forward(100)
 turtle.done()
 ```
 
-![Triangle](https://cloud-36kk4uh0h.vercel.app/triangle.gif)
+![Triangle](https://cdn.hackclub.com/rescue?url=https://cloud-36kk4uh0h.vercel.app/triangle.gif)
 
 **Star**
 ```python
@@ -245,7 +245,7 @@ for i in range(50):
 turtle.done()
 ```
 
-![Star](https://cloud-36kk4uh0h.vercel.app/star.gif)
+![Star](https://cdn.hackclub.com/rescue?url=https://cloud-36kk4uh0h.vercel.app/star.gif)
 
 **Hexagon**
 ```python
@@ -263,7 +263,7 @@ for i in range(num_sides):
 turtle.done()
 ```
 
-![Hexagon](https://cloud-36kk4uh0h.vercel.app/hexagon.gif)
+![Hexagon](https://cdn.hackclub.com/rescue?url=https://cloud-36kk4uh0h.vercel.app/hexagon.gif)
 
 Now, try creating different kinds shapes by changing the number of sides, angles and lengths of our original code using our new functions. As well, try creating more complex figures by combining and overlapping shapes.
 
@@ -282,7 +282,7 @@ for x in range(360):
     t.left(59)
 ```
 
-![Turtle Benzen ring](https://cloud-36kk4uh0h.vercel.app/turtle_benzene_ring.gif)
+![Turtle Benzen ring](https://cdn.hackclub.com/rescue?url=https://cloud-36kk4uh0h.vercel.app/turtle_benzene_ring.gif)
 
 ## Drawing
 ### pendown()
@@ -387,4 +387,4 @@ Here are some examples to give you some ideas:
 - [Geometrical Wheel Shape Demo and Code](https://repl.it/@YashKalbande/geometrical#main.py)
 - [Colorful Spiral Demo and Code](https://repl.it/@YashKalbande/spiral#main.py)
 
-![Turtle Spiral](https://cloud-36kk4uh0h.vercel.app/spiral.gif)
+![Turtle Spiral](https://cdn.hackclub.com/rescue?url=https://cloud-36kk4uh0h.vercel.app/spiral.gif)

--- a/jams/singles/3d-club-village/en-US.md
+++ b/jams/singles/3d-club-village/en-US.md
@@ -4,14 +4,14 @@ description: >
   In this jam, you'll create your very own virtual sky village with Spline, a web-based 3D modeling software.
 contributor: 'linkai101'
 contributorSlackID: 'U01R8RSGYUV'
-thumbnail: 'https://cloud-c73eqxeoz-hack-club-bot.vercel.app/00village_thumbnail_50.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-c73eqxeoz-hack-club-bot.vercel.app/00village_thumbnail_50.webp'
 timeEstimate: '60 Min'
 difficulty: 'Beginner'
 keywords: 'Web, 3D, Spline'
 language: 'Spline'
 presentation: 'https://www.figma.com/file/DYnMTevG5DWxHDcVstUzIE/Jam-Presentation---3D-Club-Village?type=design&node-id=0%3A1&mode=design&t=F8dabi5Vvsa5m6pz-1'
 presentationPlay: 'https://www.figma.com/proto/DYnMTevG5DWxHDcVstUzIE/Jam-Presentation---3D-Club-Village?type=design&node-id=1-2&t=F8dabi5Vvsa5m6pz-0&scaling=contain&page-id=0%3A1'
-presentationPDF: 'https://cloud-nd30iq2uv-hack-club-bot.vercel.app/0jam_presentation_-_3d_club_village__1_.pdf'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-nd30iq2uv-hack-club-bot.vercel.app/0jam_presentation_-_3d_club_village__1_.pdf'
 video: ''
 notes: ''
 poster: ''
@@ -21,21 +21,21 @@ slug: '3d-club-village'
 Imagine a world where you have the power to shape the landscape and design your dream buildings. **Today, we'll dive into the fundamentals of 3D modeling by building our own sky islands and collaborate by merging them into a community sky village.**
 
 Here's an example of what you'll be able to make:
-![Individual demo](https://cloud-b1g9hwiu1-hack-club-bot.vercel.app/0image.png)
+![Individual demo](https://cdn.hackclub.com/rescue?url=https://cloud-b1g9hwiu1-hack-club-bot.vercel.app/0image.png)
 [Demo](https://app.spline.design/file/dd7decef-bf50-4ca5-bff5-d76ba64513c4)
 
 And... here's an example of a sky village if you put multiple islands together!
-![Group collab demo](https://cloud-8oi5u7dkg-hack-club-bot.vercel.app/0image.png)
+![Group collab demo](https://cdn.hackclub.com/rescue?url=https://cloud-8oi5u7dkg-hack-club-bot.vercel.app/0image.png)
 [Demo](https://app.spline.design/file/652cf287-958a-4b01-a818-b6a09868f645)
 
 So without further ado, let's get started!
 
 ## Getting started with Spline
 1. Head over to [spline.design](https://spline.design) and create an account. Select "New File" to get started.
-![Getting started - Step 1](https://cloud-cmkhxafch-hack-club-bot.vercel.app/1gettingstarted-1.png)
+![Getting started - Step 1](https://cdn.hackclub.com/rescue?url=https://cloud-cmkhxafch-hack-club-bot.vercel.app/1gettingstarted-1.png)
 
 2. Play around with the UI and controls!
-![Getting started - Step 2](https://cloud-cmkhxafch-hack-club-bot.vercel.app/0gettingstarted-2.png)
+![Getting started - Step 2](https://cdn.hackclub.com/rescue?url=https://cloud-cmkhxafch-hack-club-bot.vercel.app/0gettingstarted-2.png)
 **Toolbar:** Add shapes, select/view modes, and edit tools.
 - Press “+” for more tools and objects to add to the scene.
 - Press “▷” to access Play mode.  
@@ -63,7 +63,7 @@ Start thinking about what you want on your own island: your dream mansion on a m
 <Dropdown title="1. Let's start by adding the ground.">
 <Grid cols={2}>
 <GridItem>
-![Creating your island - Step 1A](https://cloud-3klicbvir-hack-club-bot.vercel.app/9creatingisland-1a.gif)
+![Creating your island - Step 1A](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/9creatingisland-1a.gif)
 </GridItem>
 <GridItem>
 Select (single-click) the square.
@@ -73,7 +73,7 @@ Rotate the square flat and change the size to 500x500.
 </GridItem>
 
 <GridItem>
-![Creating your island - Step 1B](https://cloud-3klicbvir-hack-club-bot.vercel.app/8creatingisland-1b.gif)
+![Creating your island - Step 1B](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/8creatingisland-1b.gif)
 </GridItem>
 <GridItem>
 Select (single-click) the square.
@@ -93,7 +93,7 @@ Keep in mind that you can always change these settings anytime as you add more s
 <Dropdown title="2. Create the base house model.">
 <Grid cols={2}>
 <GridItem>
-![Creating your island - Step 2A](https://cloud-3klicbvir-hack-club-bot.vercel.app/7creatingisland-2a.gif)
+![Creating your island - Step 2A](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/7creatingisland-2a.gif)
 </GridItem>
 <GridItem>
 > We’ll start with the body of the house.
@@ -106,7 +106,7 @@ Adjust settings:
 </GridItem>
 
 <GridItem>
-![Creating your island - Step 2B](https://cloud-3klicbvir-hack-club-bot.vercel.app/6creatingisland-2b.gif)
+![Creating your island - Step 2B](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/6creatingisland-2b.gif)
 </GridItem>
 <GridItem>
 Select (single-click) the cube. Adjust settings:
@@ -125,7 +125,7 @@ In the toolbar, select the `Vertex (V)` select tool.
 </GridItem>
 
 <GridItem>
-![Creating your island - Step 2C](https://cloud-3klicbvir-hack-club-bot.vercel.app/5creatingisland-2c.gif)
+![Creating your island - Step 2C](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/5creatingisland-2c.gif)
 </GridItem>
 <GridItem>
 > Now, let’s make the roof.
@@ -140,7 +140,7 @@ Exit (”X”) out and drag the roof down. Repeat the above steps until the roof
 </GridItem>
 
 <GridItem>
-![Creating your island - Step 2D](https://cloud-3klicbvir-hack-club-bot.vercel.app/4creatingisland-2d.gif)
+![Creating your island - Step 2D](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/4creatingisland-2d.gif)
 </GridItem>
 <GridItem>
 > Let’s add some roundness to the roof.
@@ -156,7 +156,7 @@ In the toolbar, select the `Loop Cut (C)` tool.
 </GridItem>
 
 <GridItem>
-![Creating your island - Step 2E](https://cloud-3klicbvir-hack-club-bot.vercel.app/3creatingisland-2e.gif)
+![Creating your island - Step 2E](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/3creatingisland-2e.gif)
 </GridItem>
 <GridItem>
 > Now some roundness for the walls.
@@ -169,7 +169,7 @@ Repeat the above steps on the body.
 <Dropdown title="3. Add colors!">
 <Grid cols={2}>
 <GridItem>
-![Creating your island - Step 3A](https://cloud-3klicbvir-hack-club-bot.vercel.app/2creatingisland-3a.gif)
+![Creating your island - Step 3A](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/2creatingisland-3a.gif)
 </GridItem>
 <GridItem>
 > Our scene desperately needs a makeover. Let’s start with the background!
@@ -179,7 +179,7 @@ Click the background to deselect all objects. Adjust scene settings:
 </GridItem>
 
 <GridItem>
-![Creating your island - Step 3B](https://cloud-3klicbvir-hack-club-bot.vercel.app/1creatingisland-3b.gif)
+![Creating your island - Step 3B](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/1creatingisland-3b.gif)
 </GridItem>
 <GridItem>
 <Comment githubUser="linkai101">
@@ -198,7 +198,7 @@ In “Ramp”, select colors for dirt and grass and adjust their positions.
 </GridItem>
 
 <GridItem>
-![Creating your island - Step 3C](https://cloud-3klicbvir-hack-club-bot.vercel.app/0creatingisland-3c.gif)
+![Creating your island - Step 3C](https://cdn.hackclub.com/rescue?url=https://cloud-3klicbvir-hack-club-bot.vercel.app/0creatingisland-3c.gif)
 </GridItem>
 <GridItem>
 Repeat for the walls and the roof. Make it your own!
@@ -209,7 +209,7 @@ Repeat for the walls and the roof. Make it your own!
 <Dropdown title="4. Add doors, windows, and doorknobs.">
 <Grid cols={2}>
 <GridItem>
-![Creating your island - Step 4](https://cloud-kv6txjh6s-hack-club-bot.vercel.app/4creatingisland-4.png)
+![Creating your island - Step 4](https://cdn.hackclub.com/rescue?url=https://cloud-kv6txjh6s-hack-club-bot.vercel.app/4creatingisland-4.png)
 </GridItem>
 <GridItem>
 > You’re on your own for this one. You got this!
@@ -224,7 +224,7 @@ Add rounding and color to them as well.
 <Dropdown title="5. Add trees.">
 <Grid cols={2}>
 <GridItem>
-![Creating your island - Step 5](https://cloud-kv6txjh6s-hack-club-bot.vercel.app/3creatingisland-5.png)
+![Creating your island - Step 5](https://cdn.hackclub.com/rescue?url=https://cloud-kv6txjh6s-hack-club-bot.vercel.app/3creatingisland-5.png)
 </GridItem>
 <GridItem>
 > You’re on your own for this one. You got this!
@@ -238,7 +238,7 @@ Add rounding and color to them as well. Try using a Depth material for a gradien
 <Dropdown title="6. Add shadows influenced by surrounding color.">
 <Grid cols={2}>
 <GridItem>
-![Creating your island - Step 6](https://cloud-kv6txjh6s-hack-club-bot.vercel.app/2creatingisland-6.gif)
+![Creating your island - Step 6](https://cdn.hackclub.com/rescue?url=https://cloud-kv6txjh6s-hack-club-bot.vercel.app/2creatingisland-6.gif)
 </GridItem>
 <GridItem>
 > Let’s add a green glow effect coming from the trees!
@@ -263,7 +263,7 @@ Drag the origin of the layer to the tree and adjust the end position.
 <Dropdown title="7. Build a stone path to the door.">
 <Grid cols={2}>
 <GridItem>
-![Creating your island - Step 7](https://cloud-kv6txjh6s-hack-club-bot.vercel.app/1creatingisland-7.gif)
+![Creating your island - Step 7](https://cdn.hackclub.com/rescue?url=https://cloud-kv6txjh6s-hack-club-bot.vercel.app/1creatingisland-7.gif)
 </GridItem>
 <GridItem>
 > Let’s build a stone path toward the door!
@@ -298,7 +298,7 @@ Now you know the basics of Spline, **it's time to start making the island your o
 ### Spline’s asset library
 Spline has a ***huge*** library of 3D models and scenes for you to use in your project! Sprinkle little details into your island or add full building prefabs to form towns and parks.
 
-![Spline's asset library](https://cloud-kv6txjh6s-hack-club-bot.vercel.app/0splinelibrary.png)
+![Spline's asset library](https://cdn.hackclub.com/rescue?url=https://cloud-kv6txjh6s-hack-club-bot.vercel.app/0splinelibrary.png)
 
 ## Build a collaborative sky village by linking islands 🌉
 Collaboration is one of the most fun and fulfilling aspects of design and making, and Spline makes it super easy! If you're working with a group or wanna collab with a few friends, let's build a sky village!
@@ -308,10 +308,10 @@ Note: Spline's free tier currently only has 2 additional editor seats. (file own
 </Comment>
 
 1. Have the club/group leader create a new file on Spline. Share the file with the rest of the group with editing privileges.
-![Linking islands - Step 1](https://cloud-mn9anfpic-hack-club-bot.vercel.app/0image.png)
+![Linking islands - Step 1](https://cdn.hackclub.com/rescue?url=https://cloud-mn9anfpic-hack-club-bot.vercel.app/0image.png)
 
 2. Copy and paste each island into this master file. Connect them with bridges in the asset library or find your own creative way to link the islands!
-![Group collab demo](https://cloud-8oi5u7dkg-hack-club-bot.vercel.app/0image.png)
+![Group collab demo](https://cdn.hackclub.com/rescue?url=https://cloud-8oi5u7dkg-hack-club-bot.vercel.app/0image.png)
 
 ## What's next 🔮
 3D modeling literally has limitless possibilities. Here are a few:
@@ -331,7 +331,7 @@ Keep in mind that some export options are only available to the paid tiers. 😐
 </Comment>
 
 1. In the toolbar, click on "Export". There will be options on the left-hand side for various file formats to export to.
-![Exporting](https://cloud-ctimzr33x-hack-club-bot.vercel.app/0image.png)
+![Exporting](https://cdn.hackclub.com/rescue?url=https://cloud-ctimzr33x-hack-club-bot.vercel.app/0image.png)
 
 ### Jams to do next
 > Looking for more 3D jams? I gotchu!

--- a/jams/singles/3d-website/en-US.md
+++ b/jams/singles/3d-website/en-US.md
@@ -2,14 +2,14 @@
 title: Making 3D Worlds in HTML
 description: 
 contributor: shubhampatilsd
-thumbnail: 'https://cloud-mh2cnr5di-hack-club-bot.vercel.app/0slide_16_9_-_1thumbnail.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-mh2cnr5di-hack-club-bot.vercel.app/0slide_16_9_-_1thumbnail.png'
 timeEstimate: 90 Min
 difficulty: Beginner
 keywords: 3D, Web, VR
 language: HTML, CSS, JavaScript
 presentation: "https://www.figma.com/design/mxwZ1xrkPSWKDvU3VTX9Au/Hackaccino-Slides?node-id=1-2&t=VJbkLd4RrosLFv3R-1"
 presentationPlay: 'https://www.figma.com/proto/mxwZ1xrkPSWKDvU3VTX9Au/Hackaccino-Slides?page-id=0%3A1&node-id=1-2&viewport=-7853%2C490%2C0.74&t=V1iwVSMKcxtlBxPL-1&scaling=contain&content-scaling=fixed'
-presentationPDF: 'https://cloud-snbrt3xlv-hack-club-bot.vercel.app/0hackaccino_slides.pdf'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-snbrt3xlv-hack-club-bot.vercel.app/0hackaccino_slides.pdf'
 notes: 
 poster: ""
 video: ""
@@ -34,25 +34,25 @@ If you've ever wanted to make your own immersive and expansive 3D worlds, you've
 10. Wrapping up
 ## Setting up Replit 
 Go to [https://replit.com](https://replit.com) and create/log into an account:
-![Replit authentication page](https://cloud-99ig98peo-hack-club-bot.vercel.app/0image.png)
+![Replit authentication page](https://cdn.hackclub.com/rescue?url=https://cloud-99ig98peo-hack-club-bot.vercel.app/0image.png)
 
 Then, go ahead and create a project by going to "Create Repl" on the sidebar > selecting HTML, CSS, JS > giving it a title > hitting "Create Repl"
 
-![Creating HTML CSS JS Repl](https://cloud-p82fpfgs2-hack-club-bot.vercel.app/0outputgif.gif)
+![Creating HTML CSS JS Repl](https://cdn.hackclub.com/rescue?url=https://cloud-p82fpfgs2-hack-club-bot.vercel.app/0outputgif.gif)
 
 ## What's A-Frame?
 
-![aframe logo](https://cloud-m5c3nxgbo-hack-club-bot.vercel.app/0image.png)
+![aframe logo](https://cdn.hackclub.com/rescue?url=https://cloud-m5c3nxgbo-hack-club-bot.vercel.app/0image.png)
 
 Building 3D worlds used to be pretty hard to approach due to its high learning curve. A-Frame is a library to help make this stuff MUCH easier. Instead of getting lost in the weeds, it provides a simple interface for you to create 3D websites.
 
 Here are some of the amazing things people have made with A-Frame:
 1. [A-Blast](https://aframe.io/a-blast/)
-![a-blast ui](https://cloud-3j84pfit2-hack-club-bot.vercel.app/0image.png)
+![a-blast ui](https://cdn.hackclub.com/rescue?url=https://cloud-3j84pfit2-hack-club-bot.vercel.app/0image.png)
 2. [Access Mars](https://accessmars.withgoogle.com/)
-![access mars preview](https://cloud-grr8upimy-hack-club-bot.vercel.app/0image.png)
+![access mars preview](https://cdn.hackclub.com/rescue?url=https://cloud-grr8upimy-hack-club-bot.vercel.app/0image.png)
 3. [Moonrider](https://moonrider.xyz/)
-![moonrider ui](https://cloud-rcqx7la5t-hack-club-bot.vercel.app/0image.png)
+![moonrider ui](https://cdn.hackclub.com/rescue?url=https://cloud-rcqx7la5t-hack-club-bot.vercel.app/0image.png)
 
 ## Adding A-Frame
 
@@ -61,7 +61,7 @@ Hey, do you notice the `<head>` tag in our HTML? Yeah, we can add a script via t
 ```js
 <script src="https://aframe.io/releases/1.6.0/aframe.min.js"></script>
 ```
-![instructions of putting script within head tag](https://cloud-byterps5u-hack-club-bot.vercel.app/0image.png)
+![instructions of putting script within head tag](https://cdn.hackclub.com/rescue?url=https://cloud-byterps5u-hack-club-bot.vercel.app/0image.png)
 
 ## Creating a scene
 
@@ -80,9 +80,9 @@ All of our elements will go here. What are these elements you might ask?
 A-Frame has different tags for different 3D elements. For example, you can use `<a-box>` to create a cube, and `<a-sphere>` to create a ball.
 
 Here are all the different kinds of elements (use `<a-[ELEMENT-NAME]>` to use these):
-![showcase of all a-frame tags](https://cloud-69ehuc8ev-hack-club-bot.vercel.app/0image.png)
+![showcase of all a-frame tags](https://cdn.hackclub.com/rescue?url=https://cloud-69ehuc8ev-hack-club-bot.vercel.app/0image.png)
 
-![visual map of entities in a scene](https://cloud-mgilf4sx7-hack-club-bot.vercel.app/0image.png)
+![visual map of entities in a scene](https://cdn.hackclub.com/rescue?url=https://cloud-mgilf4sx7-hack-club-bot.vercel.app/0image.png)
 
 Within your `<a-scene>`, add a box:
 
@@ -93,7 +93,7 @@ Within your `<a-scene>`, add a box:
 ```
 
 Click on the panel on the right and use your WASD keys + mouse to move around. You should see a box after you move around (click the run button at the top of the page if nothing shows up):
-![demo of white box ](https://cloud-klvbtj50y-hack-club-bot.vercel.app/0screen_recording_june_17.gif)
+![demo of white box ](https://cdn.hackclub.com/rescue?url=https://cloud-klvbtj50y-hack-club-bot.vercel.app/0screen_recording_june_17.gif)
 
 Hmm, we should probably have some color. After all, things are much better with colors!
 
@@ -125,13 +125,13 @@ It's really simple to deploy your site. Go to https://netlify.app and create an 
 
 After doing so, go to Replit and download your files as a `.zip` file. You can do this by clicking the three dots above all your files and clicking "Download as ZIP":
 
-![image of ui to download as zip](https://cloud-ecgsox4ue-hack-club-bot.vercel.app/0image.png)
+![image of ui to download as zip](https://cdn.hackclub.com/rescue?url=https://cloud-ecgsox4ue-hack-club-bot.vercel.app/0image.png)
 
 After this, go to https://app.netlify.com/drop and drag and drop your `.zip` file there.
 
 After it uploads, click "Open production deploy" to see your live site!
 
-![image of opening deploy](https://cloud-bpr687t0e-hack-club-bot.vercel.app/0image.png)
+![image of opening deploy](https://cdn.hackclub.com/rescue?url=https://cloud-bpr687t0e-hack-club-bot.vercel.app/0image.png)
 
 ## Getting a free frappuccino
 
@@ -146,13 +146,13 @@ Awesome work on this site! To wrap up, we suggest sharing your site in our [Slac
 Here's some cool stuff that Hack Clubbers have made:
 
 1. [Adrian De Gendt](https://github.com/Space1415/) made an amazing [solar system model](https://subsequent-thoughtful-tarantula.glitch.me/) 
-![solar system example from adrian de gendt](https://cloud-1e2jtrqm9-hack-club-bot.vercel.app/0image.png)
+![solar system example from adrian de gendt](https://cdn.hackclub.com/rescue?url=https://cloud-1e2jtrqm9-hack-club-bot.vercel.app/0image.png)
 
 2. [Aayan Rahman](https://github.com/aayanrahman/) made [Bloxy](https://aayanrahman.github.io/HackaccinoGrant.github.io/), a block-game demo inspired by Minecraft 
-![bloxy demo](https://cloud-c2fzf76vl-hack-club-bot.vercel.app/0image.png)
+![bloxy demo](https://cdn.hackclub.com/rescue?url=https://cloud-c2fzf76vl-hack-club-bot.vercel.app/0image.png)
 
 3. [Dieter Schoening](https://github.com/Deetschoe) made [Aurality](https://aurality.vercel.app/), a webapp that displays your Spotify top songs in 3D!
-![aurality demo](https://cloud-a5dhhs37l-hack-club-bot.vercel.app/0image.png)
+![aurality demo](https://cdn.hackclub.com/rescue?url=https://cloud-a5dhhs37l-hack-club-bot.vercel.app/0image.png)
 
 So there you have it, go out and create great things with the tools and skills you have.
 

--- a/jams/singles/ai-travel/en-US.md
+++ b/jams/singles/ai-travel/en-US.md
@@ -4,14 +4,14 @@ description: >
   This Jam will teach you how to use ChatGPT and AI to create a trip itinerary planner. It is extremely customizable and gives a foundation for you to expand upon with your own ideas!
 contributor: 'ShubhamPatilsd'  
 contributorSlackID: 'U029D5FG8EN'
-thumbnail: 'https://cloud-obssy416r-hack-club-bot.vercel.app/00000image__2___1_-2_50.webp'  
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-obssy416r-hack-club-bot.vercel.app/00000image__2___1_-2_50.webp'  
 timeEstimate: '60 Min'  
 difficulty: 'Intermediate'  
 keywords: 'replit, API, trip itinerary, itinerary planner ai, planner ai, website, javascript, HTML, CSS, AI, chatgpt, openai, ai, ai api'  
 language: 'HTML, JS'  
 presentation: 'https://www.figma.com/file/eT0znn6hYdESlhCSfmmwBG/Untitled?type=design&node-id=1%3A2&mode=design&t=6KWZTxjPBdL20osY-1'  
 presentationPlay: 'https://www.figma.com/proto/eT0znn6hYdESlhCSfmmwBG/Untitled?type=design&node-id=1-2&t=jECJDbIDCUZQwKjc-1&scaling=contain&page-id=0%3A1&mode=design'  
-presentationPDF: 'https://cloud-opfk4nagv-hack-club-bot.vercel.app/0ai_trip_itinerary_planner.pdf'  
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-opfk4nagv-hack-club-bot.vercel.app/0ai_trip_itinerary_planner.pdf'  
 notes: ''  
 poster: ''  
 video: ''  
@@ -26,7 +26,7 @@ Take some time as a club to brainstorm the greatest place to take a vacation. Ma
 However, you might have run into a problem: you can't think of things to do! For example, in San Francisco, you might think of going to the Golden Gate Bridge, but what else?
 
 This is where we can use AI and code to solve our problem by making an AI travel itinerary planner:
-![Live Demo Gif](https://cloud-j37pzs32q-hack-club-bot.vercel.app/0plantripwithaigif.gif)
+![Live Demo Gif](https://cdn.hackclub.com/rescue?url=https://cloud-j37pzs32q-hack-club-bot.vercel.app/0plantripwithaigif.gif)
 
 Try it out [here](https://replit.com/@ShubhamPatilsd/AI-Trip-Itinerary)!
 
@@ -45,10 +45,10 @@ So, you decide to get started! You log onto your laptop and then realize that yo
 You take two deep breaths and realize that you can just use Replit to do this.
 
 So you go to https://replit.com and sign up for an account.
-![login page](https://cloud-2vb2zquzl-hack-club-bot.vercel.app/0pasted_image_20230714142545.png)
+![login page](https://cdn.hackclub.com/rescue?url=https://cloud-2vb2zquzl-hack-club-bot.vercel.app/0pasted_image_20230714142545.png)
 
 Then, you create a new project with the HTML, CSS, and JS template
-![create repl](https://cloud-2vb2zquzl-hack-club-bot.vercel.app/1pasted_image_20230714142701.png)
+![create repl](https://cdn.hackclub.com/rescue?url=https://cloud-2vb2zquzl-hack-club-bot.vercel.app/1pasted_image_20230714142701.png)
 
 
 ## Inputting information
@@ -86,7 +86,7 @@ Underneath your `location` input, add two of these and assign them unique names:
 ```
 
 At this stage, you should have something like this:
-![result](https://cloud-2vb2zquzl-hack-club-bot.vercel.app/2pasted_image_20230715110807.png)
+![result](https://cdn.hackclub.com/rescue?url=https://cloud-2vb2zquzl-hack-club-bot.vercel.app/2pasted_image_20230715110807.png)
 
 
 ### Adding more inputs
@@ -124,7 +124,7 @@ Our Cool And Easy to Digest™ Definition:
 title="So which API are we using?"
 >
 Great question! Let's break down the API structure for ChatGPT!
-![explanation of API](https://cloud-647cibhzc-hack-club-bot.vercel.app/0hack_club_jam.png)
+![explanation of API](https://cdn.hackclub.com/rescue?url=https://cloud-647cibhzc-hack-club-bot.vercel.app/0hack_club_jam.png)
 
 We are going to be using the `/v1/chat/completions` endpoint to get the job done; it's the core technology behind ChatGPT!
 
@@ -140,7 +140,7 @@ We can send a ***"request"*** to our API in order to talk to it.
 ### Types of Requests
 There are four types of requests: GET, POST, PUT, and DELETE
 
-![](https://cloud-c8wbo8ip9-hack-club-bot.vercel.app/0image2.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-c8wbo8ip9-hack-club-bot.vercel.app/0image2.png)
 
 > GET: We tell the API to fetch some data for us to use<br/>
 > POST: We tell the API to create some data for us<br/>
@@ -171,7 +171,7 @@ Since we're going to be sending a `POST` request, that also means that we have t
 
 Think of the request as a cardboard box and the body being the stuff that goes inside that box. We (our browser) can then package and ship that box to the API.
 
-![explanation of api request body](https://cloud-iux06nddt-hack-club-bot.vercel.app/0untitled.png)
+![explanation of api request body](https://cdn.hackclub.com/rescue?url=https://cloud-iux06nddt-hack-club-bot.vercel.app/0untitled.png)
 
 Here's the request body that we use to communicate with the ChatGPT API:
 ```json
@@ -287,7 +287,7 @@ Ideally, this form should be able to pass the values of our `<input/>` parameter
 Let's try running this and see if we get a `console.log` in the browser console!
 
 Hint: Open the developer tools in Replit to see the console! It's the wrench icon right here:
-![open the wrench icon in replit to see dev tools](https://cloud-88lqktoh1-hack-club-bot.vercel.app/0image.png)
+![open the wrench icon in replit to see dev tools](https://cdn.hackclub.com/rescue?url=https://cloud-88lqktoh1-hack-club-bot.vercel.app/0image.png)
 
 ---
 
@@ -330,7 +330,7 @@ function getItinerary(event) {
 ```
 
 Nice! We just got something in the console!
-![console.log output showing in the console](https://cloud-lx8djo7vn-hack-club-bot.vercel.app/0image.png)
+![console.log output showing in the console](https://cdn.hackclub.com/rescue?url=https://cloud-lx8djo7vn-hack-club-bot.vercel.app/0image.png)
 
 ### We're making so much progress! Great work!
 ![great work gif](https://gifdb.com/images/high/great-job-guys-jimmy-fallon-wsvujhpbhgk80bh7.gif)
@@ -368,7 +368,7 @@ function getItinerary(event) {
 **Also remember to add any additional input elements that you made at the start!**
 
 Run your code, type in your location and dates, click submit, and check in the console! This is what I got:
-![result with everything printed](https://cloud-giko7ueoa-hack-club-bot.vercel.app/0image.png)
+![result with everything printed](https://cdn.hackclub.com/rescue?url=https://cloud-giko7ueoa-hack-club-bot.vercel.app/0image.png)
 
 ## Interacting with the ChatGPT API
 This is going great so far! We have all the values from our input elements. Now the only thing left is to communicate with the ChatGPT API.
@@ -438,13 +438,13 @@ fetch('https://api.openai.com/v1/chat/completions', {
 Well, some APIs need to verify that we're authorized to use them. This could be because it's too expensive to run those APIs and they need some way to limit usage or keep track of who is using them.
 
 Let's add something to our diagram:
-![headers are like the labels on a package](https://cloud-27qdx0gbm-hack-club-bot.vercel.app/0untitledheaders.png)
+![headers are like the labels on a package](https://cdn.hackclub.com/rescue?url=https://cloud-27qdx0gbm-hack-club-bot.vercel.app/0untitledheaders.png)
 
 You know how the labels on a package can identify who sent the package? Likewise, request headers also identify who is sending the request.
 
 Most often, APIs use something called an **API key** to check who sent the information. They distribute these keys and each one is unique, which means that given a key, they can find out who they handed it out to.
 
-![the api developer hands out keys to each unique user](https://cloud-hqp06ld4l-hack-club-bot.vercel.app/0keyexplanation.png)
+![the api developer hands out keys to each unique user](https://cdn.hackclub.com/rescue?url=https://cloud-hqp06ld4l-hack-club-bot.vercel.app/0keyexplanation.png)
 
 To contact the ChatGPT API, we need to send these `headers` in the `fetch` request:
 ```js
@@ -461,8 +461,8 @@ Let's break this down:
 **Hmm, what API Key should I get?**
 Good observation, we need an API key. Here are the steps on how to do so:
 1. Create an account on the [OpenAI Platform](https://platform.openai.com/)
-2. Go to the API keys page:![click the user profile and in the popup, click view api keys](https://cloud-873naq3sb-hack-club-bot.vercel.app/0image.png)
-3. Create a new API key secret:![button to create new api key secret](https://cloud-ee2akama4-hack-club-bot.vercel.app/0image.png)
+2. Go to the API keys page:![click the user profile and in the popup, click view api keys](https://cdn.hackclub.com/rescue?url=https://cloud-873naq3sb-hack-club-bot.vercel.app/0image.png)
+3. Create a new API key secret:![button to create new api key secret](https://cdn.hackclub.com/rescue?url=https://cloud-ee2akama4-hack-club-bot.vercel.app/0image.png)
 4. Replace `OPENAI_API_KEY` with your new API key!
 
 Now, your `fetch` request should look something like this:
@@ -922,7 +922,7 @@ And this is my `index.html` file:
 Now, if you run this code, and type in some inputs, you should get a trip itinerary beautifully displayed on your screen!
 
 **Result:**
-![result](https://cloud-r7dc1z25v-hack-club-bot.vercel.app/0image.png)
+![result](https://cdn.hackclub.com/rescue?url=https://cloud-r7dc1z25v-hack-club-bot.vercel.app/0image.png)
 
 
 ---

--- a/jams/singles/animated-3d-model/en-US.md
+++ b/jams/singles/animated-3d-model/en-US.md
@@ -4,7 +4,7 @@ description: >
   Animate your own 3D Models.
 contributor: 'zoya-hussain'
 originalAuthor: 'wollygfx'
-thumbnail: 'https://cloud-f0her7co2.vercel.app/2020-10-21_84xj5ymva0f16vfmyderfn46epzgzbp7.jpeg'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-f0her7co2.vercel.app/2020-10-21_84xj5ymva0f16vfmyderfn46epzgzbp7.jpeg'
 timeEstimate: '45 Min'
 difficulty: 'Beginner'
 keywords: 'Beta, 3D, Animated, Animated 3D Model, 3D'
@@ -32,18 +32,18 @@ Time: 45-50 minutes, Beginner
 5. **Additional Challenges**: Once you've nailed down the basics of 3D modeling with JS, check out some challenges to spice up your project 🌶️
 
 At the end of this workshop, you will be able to make 3D models like these:
-![examples](https://cloud-5a0ya05fk.vercel.app/0large.gif)
+![examples](https://cdn.hackclub.com/rescue?url=https://cloud-5a0ya05fk.vercel.app/0large.gif)
 
 Here's a [live demo](https://repl.it/@wollygfx/Hack-Club-logo) of what we will make, you can also find the final code there.
 
-![Hack Club 3D logo](https://cloud-590c1rr82.vercel.app/0screen_recording_2020-10-21_at_7.00.53_am.gif)
+![Hack Club 3D logo](https://cdn.hackclub.com/rescue?url=https://cloud-590c1rr82.vercel.app/0screen_recording_2020-10-21_at_7.00.53_am.gif)
 
 ## Set Up
 This workshop requires a very basic knowledge of the following languages: HTML & JS. Don’t worry if you get stuck at some point in the workshop, everything is explained the best way for you to understand!
 
 For this workshop we will use [Repl.it](https://repl.it), click [here](https://repl.it/languages/html) to create a coding environment right for this workshop.
 
-![Setup](https://cloud-qbmylslty.vercel.app/0image.png)
+![Setup](https://cdn.hackclub.com/rescue?url=https://cloud-qbmylslty.vercel.app/0image.png)
 
 ## HTML part
 
@@ -76,7 +76,7 @@ _Note: It’s very important to keep this order to make sure everything works pe
 ## JS part
 Now that we have our HTML file ready to go, we gotta work on our JavaScript file.
 
-![Cool gif](https://cloud-p49mi1lgl.vercel.app/0tumblr_e49d74c805eec46704d22c1da59ecded_cc93a056_500.gif)
+![Cool gif](https://cdn.hackclub.com/rescue?url=https://cloud-p49mi1lgl.vercel.app/0tumblr_e49d74c805eec46704d22c1da59ecded_cc93a056_500.gif)
 
 ### Setting up the canvas
 We are going to start with the fun part. First, let’s create the main variable and let’s give it a name. Feel free to give your variables [any name](https://sentry.io/answers/naming-variables-in-javascript/). For this tutorial, I'll use “ws”.
@@ -138,11 +138,11 @@ This code updates and render your Zdog illustration that was declared in the fir
 
 Now let's click on the **Run** button to see what happens…
 
-![Render image](https://cloud-k11ck8g2n.vercel.app/0image.png)
+![Render image](https://cdn.hackclub.com/rescue?url=https://cloud-k11ck8g2n.vercel.app/0image.png)
 
 Congrats, you just made your first 3D model… Yeah, maybe not what you were expecting. Let’s fix this by animating it.
 
-![woah gif](https://cloud-kr2lyxjbx.vercel.app/0woah.gif)
+![woah gif](https://cdn.hackclub.com/rescue?url=https://cloud-kr2lyxjbx.vercel.app/0woah.gif)
 
 ### Animating it
 Add the following code to our JS file:
@@ -170,18 +170,18 @@ Explanation:
 
 Now you can click on run again!
 
-![Animated model](https://cloud-djkuut7y4.vercel.app/0screen_recording_2020-10-03_at_7.31.47_pm.gif)
+![Animated model](https://cdn.hackclub.com/rescue?url=https://cloud-djkuut7y4.vercel.app/0screen_recording_2020-10-03_at_7.31.47_pm.gif)
 
 Amazing, huh?
 
-![Amazing gif](https://cloud-hrs0t8jeh.vercel.app/0tenor.gif)
+![Amazing gif](https://cdn.hackclub.com/rescue?url=https://cloud-hrs0t8jeh.vercel.app/0tenor.gif)
 
 Now, go ahead and experiment with the other shapes offered by Zdog (spheres, cylinders, cones, or even custom shapes) and explore the possibilities for creating your own unique 3D models!
 
 ### Multiple Shapes
 If you want to try and make more complex models you will need to use multiple shapes, [here](https://zzz.dog/#made-with-zdog) are some examples of what you can create:
 
-![examples](https://cloud-2jaw6a14x.vercel.app/0image.png)
+![examples](https://cdn.hackclub.com/rescue?url=https://cloud-2jaw6a14x.vercel.app/0image.png)
 
 Making multiple shapes is very easy, it’s as simple as putting multiple shapes together until you get what you want. The hardest part of this is to put everything where it must be, we can do this using the property: “translate”. 
 
@@ -248,7 +248,7 @@ new Zdog.Box({
 - This time, the shape is moved forward… This creates an space between the red square and this new shape.
 - The shape is moved to the left within the x-axis
 
-![result 1](https://cloud-kg0xtr3hs.vercel.app/0image.png)
+![result 1](https://cdn.hackclub.com/rescue?url=https://cloud-kg0xtr3hs.vercel.app/0image.png)
 
 ```javascript
 new Zdog.Box({
@@ -264,7 +264,7 @@ new Zdog.Box({
 - This time, we created a new box but way smaller.
 - We moved it to the right within x-axis and a little bit down within the y-axis.
 
-![result 2](https://cloud-1nisp19i8.vercel.app/0image.png)
+![result 2](https://cdn.hackclub.com/rescue?url=https://cloud-1nisp19i8.vercel.app/0image.png)
 
 ```javascript
 new Zdog.Box({
@@ -279,7 +279,7 @@ new Zdog.Box({
 
 In this last one, all we had to do was to move the box to the right within the x-axis, so that it blends with the box in the right.
 
-![result 3](https://cloud-m2gpkvlqa.vercel.app/0image.png)
+![result 3](https://cdn.hackclub.com/rescue?url=https://cloud-m2gpkvlqa.vercel.app/0image.png)
 
 Now let's update the animation function with some simple properties:
 
@@ -295,12 +295,12 @@ animateModel()
 
 Here's the final result:
 
-![final result](https://cloud-d9lxnrldx.vercel.app/0screen_recording_2020-10-09_at_12.05.02_pm.gif)
+![final result](https://cdn.hackclub.com/rescue?url=https://cloud-d9lxnrldx.vercel.app/0screen_recording_2020-10-09_at_12.05.02_pm.gif)
 
 ### Level up
 Congratulations! You just learned the basics of Zdog, feel free to check the resources below to improve your knowledge...
 
-![Congrats gif](https://cloud-d0aqa4icc.vercel.app/0bec38a05d56ac6ae2d9dec2f482ebff9.gif)
+![Congrats gif](https://cdn.hackclub.com/rescue?url=https://cloud-d0aqa4icc.vercel.app/0bec38a05d56ac6ae2d9dec2f482ebff9.gif)
 
 Make your own 3D Model and share it in the [Hack Club Slack](https://hackclub.slack.com), I would love to see what you can create using what you've learned in this workshop!
 

--- a/jams/singles/bakebuild/en-US.md
+++ b/jams/singles/bakebuild/en-US.md
@@ -3,7 +3,7 @@ title: 'BakeBuild'
 description: 'Model a cookie, get it printed for you, and receive a cookie grant.'
 contributor: 'Kaympe20'
 contributorSlackID: 'U07HY92M9GA'
-thumbnail: 'https://cloud-rlzztwel4-hack-club-bot.vercel.app/0slide1.jpg'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-rlzztwel4-hack-club-bot.vercel.app/0slide1.jpg'
 timeEstimate: '40 Min'
 difficulty: 'Beginner'
 keywords: '3D printing, cookie cutter, modeling, design, baking, Hackclub, YSWS, beginner project, hands-on, creative, STEM, CAD, cookie grant, workshop, fun activity'
@@ -35,7 +35,7 @@ slug: 'bakebuild'
     * Talk to your friends and brainstorm ideas​
     * Sketch an outline of it using either digital tools or paper
 * Find something that has a simple outline, like this loch ness monster!
-![](https://cloud-j3vzjmngz-hack-club-bot.vercel.app/0picture.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-j3vzjmngz-hack-club-bot.vercel.app/0picture.png)
 * Once you’ve got your outline, save an image of it to your computer and return to Onshape!
 
 ## Importing the image into onshape
@@ -45,24 +45,24 @@ slug: 'bakebuild'
     * Click on the last option “import”​
 * Select your chosen file and click “open”​
 * A loading bar will appear and tell you once your image has been successfully imported
-![](https://cloud-4ld7cxlyw-hack-club-bot.vercel.app/4image6.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-4ld7cxlyw-hack-club-bot.vercel.app/4image6.png)
 
 ## Insert the picture
 * Now it’s time to add the image!​
 * Create a sketch on the top plane and insert the photo ​
 * Using the dropdown from “Insert DXF or DWG,” click on “Insert Image”​
 * An option to insert an image will appear
-![](https://cloud-i4xfog8ph-hack-club-bot.vercel.app/0image7.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-i4xfog8ph-hack-club-bot.vercel.app/0image7.png)
 * Choose your image from the pop-up​
 * Click on the pane you want to drag to draw your image​
 * DO NOT CONFIRM YOUR SKETCH YET
-![](https://cloud-jverinan3-hack-club-bot.vercel.app/0image8.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-jverinan3-hack-club-bot.vercel.app/0image8.png)
 
 
 ## Dimension
 * Use the dimensioning tool to change the size of your picture​
 * In general, your outline probably shouldn’t be over 4in x 4in or 100mm x 100mm
-![](https://cloud-jverinan3-hack-club-bot.vercel.app/1image9.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-jverinan3-hack-club-bot.vercel.app/1image9.png)
 
 
 ## Tracing
@@ -70,12 +70,12 @@ slug: 'bakebuild'
 * Use the spline tool and click along your outline to trace it out!​
     * Note that you can edit the points of your spline after confirming it but you cannot undo any (DO NOT TRY UNDOING WHILE MAKING THE OUTLINE)​
 * Once you’re happy with your outline, confirm your sketch by clicking on the green checkmark​
-![](https://cloud-jverinan3-hack-club-bot.vercel.app/2image10.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-jverinan3-hack-club-bot.vercel.app/2image10.png)
 
 ## 3D time
 * Once your sketch is confirmed, click the extrude tool and choose “thin” ​
 * Then select the outline of your sketch​
-![](https://cloud-11umbk5i1-hack-club-bot.vercel.app/0image11.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-11umbk5i1-hack-club-bot.vercel.app/0image11.png)
 * Now you can change the thickness​
 * I find that  2mm/.08in work best​
 * Then choose the depth​
@@ -87,7 +87,7 @@ slug: 'bakebuild'
 * Select the bottom side of the extrude and use thin to make a pretty border​
     * Thickness ~ 5mm​
     * Depth ~ 2mm
-![](https://cloud-11umbk5i1-hack-club-bot.vercel.app/2image13.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-11umbk5i1-hack-club-bot.vercel.app/2image13.png)
 
 ## ADMIRE IT!​
 * Look at your finished design!​
@@ -98,13 +98,13 @@ slug: 'bakebuild'
 ## Screenshot
 * Take a screenshot of your design (like so) and save it to your computer​
 * You will need this for submission
-![](https://cloud-11umbk5i1-hack-club-bot.vercel.app/3image14.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-11umbk5i1-hack-club-bot.vercel.app/3image14.png)
 
 ## Export
 * Now it’s time to export it!​
 * Right click the “part studio” tab where you made your whole design ​
 * Select “export”
-![](https://cloud-11umbk5i1-hack-club-bot.vercel.app/4image15.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-11umbk5i1-hack-club-bot.vercel.app/4image15.png)
 * A pop up will appear​
 * Name your file something relevant and boring like ​“Cookie Cutter” again​
 * Select “STEP” for the format​

--- a/jams/singles/building-social-media-apps/en-US.md
+++ b/jams/singles/building-social-media-apps/en-US.md
@@ -4,14 +4,14 @@ description: >
     At the end of this jam, you'll create your very own social media app that handles users and posts.
 contributor: "InternetRamen"
 contributorSlackID: "U03AUPJQKLN"
-thumbnail: "https://cloud-30x6q0o6o-hack-club-bot.vercel.app/0000slide_16_9_-_3__1__50.webp"
+thumbnail: "https://cdn.hackclub.com/rescue?url=https://cloud-30x6q0o6o-hack-club-bot.vercel.app/0000slide_16_9_-_3__1__50.webp"
 timeEstimate: "60 Min"
 difficulty: "Intermediate"
 keywords: "Web, App, Website, JavaScript"
 language: "HTML & JS"
 presentation: "https://www.figma.com/file/erQf158AHyOtwmEqWUyI1p/Building-your-own-social-media-app?type=design&node-id=2%3A2&mode=design&t=hpquuvbUlSrQk1HU-1"
 presentationPlay: "https://www.figma.com/proto/erQf158AHyOtwmEqWUyI1p/Building-your-own-social-media-app?type=design&node-id=2-4&t=UixZlCs2fBTa1TgT-1&scaling=contain&page-id=2%3A2&mode=design"
-presentationPDF: "https://cloud-hl5mkgjy0-hack-club-bot.vercel.app/0building_your_own_social_media_app.pdf"
+presentationPDF: "https://cdn.hackclub.com/rescue?url=https://cloud-hl5mkgjy0-hack-club-bot.vercel.app/0building_your_own_social_media_app.pdf"
 notes: ""
 poster: ""
 video: ""
@@ -22,7 +22,7 @@ At the end of this jam, we'll create a social media app that handles users and p
 We'll be using [Firebase](https://firebase.google.com) SDKs to help us with user authentication and data storage.
 
 Here's a demo of something you could build:
-![Demo](https://cloud-aspwulevx-hack-club-bot.vercel.app/0document.png)
+![Demo](https://cdn.hackclub.com/rescue?url=https://cloud-aspwulevx-hack-club-bot.vercel.app/0document.png)
 
 [Link To Live Demo](https://demo.jaden.mov)
 
@@ -62,7 +62,7 @@ On each page, we have a basic HTML boilerplate with script and style tags. Conve
 Head over to [Firebase Console](https://console.firebase.google.com/u/0/) and log in with Google. Once you're in, create a new project and name it whatever you want.
 
 Then, click and enable `Authentication` and `Firestore Database`.
-![Console](https://cloud-5uj5nkwmd-hack-club-bot.vercel.app/0image-1.png)
+![Console](https://cdn.hackclub.com/rescue?url=https://cloud-5uj5nkwmd-hack-club-bot.vercel.app/0image-1.png)
 
 **Authentication**
 
@@ -83,7 +83,7 @@ Sharks...do not have bones
 
 ### Creating an app in Firebase
 
-![Console](https://cloud-aal2o35z9-hack-club-bot.vercel.app/0image-3.png)
+![Console](https://cdn.hackclub.com/rescue?url=https://cloud-aal2o35z9-hack-club-bot.vercel.app/0image-3.png)
 
 1. Click the `</>` icon
 2. Name your app anything
@@ -111,7 +111,7 @@ Here is what the code snippet looks like and what each line does:
 
 ## Logging in
 
-![Logs](https://cloud-aal2o35z9-hack-club-bot.vercel.app/1image-4.png)
+![Logs](https://cdn.hackclub.com/rescue?url=https://cloud-aal2o35z9-hack-club-bot.vercel.app/1image-4.png)
 
 Head over to `index.html`. Firebase makes it super easy to add user authentication to your app. We'll be using Google Sign-In, but you can use any of the other methods Firebase provides.
 
@@ -190,12 +190,12 @@ document.getElementById("login").addEventListener("click", () => {
 
 </Dropdown>
 
-![Login button](https://cloud-aal2o35z9-hack-club-bot.vercel.app/7image-5.png)
+![Login button](https://cdn.hackclub.com/rescue?url=https://cloud-aal2o35z9-hack-club-bot.vercel.app/7image-5.png)
 Test it out! You should receive a prompt to login. <small>[Need help?](https://firebase.google.com/docs/auth/web/google-signin)</small>
 
 ## Creating a post
 
-![Alt text](https://cloud-aal2o35z9-hack-club-bot.vercel.app/3image-7.png)
+![Alt text](https://cdn.hackclub.com/rescue?url=https://cloud-aal2o35z9-hack-club-bot.vercel.app/3image-7.png)
 
 <Dropdown title="Whale Fact!">
 Whales can get SUNBURNS
@@ -274,14 +274,14 @@ if (!currentUser) {
 `auth.currentUser` lets us access the current user. If there is no current user, the variable will be `null`, so we can alert the user and not add anything. `return` will stop the function from executing any more code.
 
 Then, create a collection in Firestore. A collection holds all your documents. It's like a bucket for all your data.
-![Alt text](https://cloud-aal2o35z9-hack-club-bot.vercel.app/4image-8.png)
-![Alt text](https://cloud-aal2o35z9-hack-club-bot.vercel.app/5image-9.png)
+![Alt text](https://cdn.hackclub.com/rescue?url=https://cloud-aal2o35z9-hack-club-bot.vercel.app/4image-8.png)
+![Alt text](https://cdn.hackclub.com/rescue?url=https://cloud-aal2o35z9-hack-club-bot.vercel.app/5image-9.png)
 
 > Choose a collection name that makes sense for your app! It doesn't have to be posts if that doesn't make sense. Maybe something like `recipes` or `clubs` would make more sense for your idea
 
 When you're prompted to create the first document, add sample data for the fields you've already created above. You can just click auto-ID for the document ID.
 _For example, in my case I'll add `name` and `description`._
-![Alt text](https://cloud-aal2o35z9-hack-club-bot.vercel.app/6image-10.png)
+![Alt text](https://cdn.hackclub.com/rescue?url=https://cloud-aal2o35z9-hack-club-bot.vercel.app/6image-10.png)
 
 Now, we can access the values of each input and add them to the database. We'll use `addDoc` to add a document to the database. `addDoc` takes in 2 parameters: the reference to the collection and the data to add. We'll use `collection` to reference the collection we want to add to, `name.value` to get the value of the first input, and `description.value` to get the value of the second input. We can also use `currentUser.displayName` to grab the name of the author to display.
 

--- a/jams/singles/colorful-grammar/en-US.md
+++ b/jams/singles/colorful-grammar/en-US.md
@@ -4,7 +4,7 @@ description: >
   Let your words color the screen as you type!
 contributor: 'sahitid'
 originalAuthor: 'MatthewStanciu'
-thumbnail: 'https://cloud-pvpvkpeuc-hack-club-bot.vercel.app/0demo.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-pvpvkpeuc-hack-club-bot.vercel.app/0demo.png'
 timeEstimate: '30-45 Min'
 difficulty: 'Beginner'
 keywords: 'Beta, color, colorful, grammar, colorful grammar'

--- a/jams/singles/components-in-a-cap/en-US.md
+++ b/jams/singles/components-in-a-cap/en-US.md
@@ -3,14 +3,14 @@ title: 'Make Your Own Electronic Trash Out Of A Magical Hat'
 description: Let's build a hacky electronics gizmo -- but with a twist -- you can only use three components that you draw out of a cap! You'll learn the basics of designing a PCB, and you can get the cards made for free, with Hack Club's OnBoard.
 contributor: 'maxwofford'
 contributorSlackID: U0C7B14Q3
-thumbnail: 'https://cloud-f9qeb5d02-hack-club-bot.vercel.app/00componentsinhat__1_.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-f9qeb5d02-hack-club-bot.vercel.app/00componentsinhat__1_.png'
 timeEstimate: '1 Hour'
 difficulty: 'Beginner'
 keywords: 'Hardware, PCB, EasyEDA, Business Card, OnBoard'
 language: 'EasyEDA'
 presentation: 'https://www.figma.com/file/5kXADOfqHzoV6kaA9xNl1T/components-jam?type=design&node-id=154%3A341&mode=design&t=pHzt7QifMykaDnCB-1'
 presentationPlay: 'https://www.figma.com/proto/5kXADOfqHzoV6kaA9xNl1T/components-jam?page-id=154%3A341&type=design&node-id=154-343&viewport=-11%2C1340%2C0.07&t=2LfA5bNVMXiFqIyP-1&scaling=contain&mode=design'
-presentationPDF: 'https://cloud-421055gkt-hack-club-bot.vercel.app/00components-jam_compressed__1_.pdf'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-421055gkt-hack-club-bot.vercel.app/00components-jam_compressed__1_.pdf'
 notes: ''
 poster: 'https://github.com/hackclub/posters#:~:text=%40Krishna%20Bansal-,Download,-Go%20to%20Figma'
 video: 'https://www.youtube.com/embed/bumzyz2advg?si=oLItGZB1qI2EQN1m'
@@ -37,26 +37,26 @@ Here's an example of what you might end up with (EXCEPT YOU'RE NOT GOING TO HAVE
 
 Combine a **Light Sensor**, **Rumble Motor**, and **Battery** to make a rattle snake that rumbles whenever you put it in the light.
 
-![rattleSnake](https://cloud-62nxyioni-hack-club-bot.vercel.app/0drawing__7_.png)
+![rattleSnake](https://cdn.hackclub.com/rescue?url=https://cloud-62nxyioni-hack-club-bot.vercel.app/0drawing__7_.png)
 
 No one has ever sat down to learn web dev & made the next facebook. Similarly, if you sit down thinking "I'm going to make something as helpful as an iPhone", you're destined for failure...
 
 But sit down to make some trash, and you'll end up with this treasure:
 
-![board color](https://cloud-plhykfmfn-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_3.23.48_pm.png)
+![board color](https://cdn.hackclub.com/rescue?url=https://cloud-plhykfmfn-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_3.23.48_pm.png)
 
 ## Get In Your Workspace
 
 Now it's the time to open up good ol' [easyeda](https://easyeda.com/)
 
 Step 1: create an account or login with google (tapping Register in the top right corner)
-![loginWithGoogle](https://cloud-8c6bzxhxx-hack-club-bot.vercel.app/0registereda.gif)
+![loginWithGoogle](https://cdn.hackclub.com/rescue?url=https://cloud-8c6bzxhxx-hack-club-bot.vercel.app/0registereda.gif)
 
 Step 2: Tap on Easy EDA Designer Open the "STD" (student) edition of EasyEDA
-![STDEdition](https://cloud-8lt1ycvzx-hack-club-bot.vercel.app/0easyeda_designer.gif)
+![STDEdition](https://cdn.hackclub.com/rescue?url=https://cloud-8lt1ycvzx-hack-club-bot.vercel.app/0easyeda_designer.gif)
 
 Step 3: Start A New Project
-![NewProject](https://cloud-3oval3xig-hack-club-bot.vercel.app/0newproject.gif)
+![NewProject](https://cdn.hackclub.com/rescue?url=https://cloud-3oval3xig-hack-club-bot.vercel.app/0newproject.gif)
 
 ## Add In Your Components
 
@@ -70,11 +70,11 @@ Once you select a component
 3. Search for your component (tap search icon)
 4. Select your component and place it anywhere on your schematic
 
-![Light Sensor](https://cloud-lvwqcxzv9-hack-club-bot.vercel.app/0getcomponentid.gif)
+![Light Sensor](https://cdn.hackclub.com/rescue?url=https://cloud-lvwqcxzv9-hack-club-bot.vercel.app/0getcomponentid.gif)
 
 Repeat this step for all 3 of your components
 
-![your components](https://cloud-ecs518tqh-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_2.48.02_pm.png)
+![your components](https://cdn.hackclub.com/rescue?url=https://cloud-ecs518tqh-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_2.48.02_pm.png)
 
 ## Wire the components up
 
@@ -82,7 +82,7 @@ Look at the documentation for each component in the [component library](https://
 
 Use R to rotate your elements and drag them around. Remember this is the NO CREATIVITY ZONE because your design will be totally moved around when you convert it to a PCB. 
 
-![wired up](https://cloud-gsil8fuxg-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_2.48.14_pm.png)
+![wired up](https://cdn.hackclub.com/rescue?url=https://cloud-gsil8fuxg-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_2.48.14_pm.png)
 
 
 ## Convert to PCB
@@ -90,41 +90,41 @@ Use R to rotate your elements and drag them around. Remember this is the NO CREA
 Save your design (control S or CMD S)
 
 Tap Convert To PCB under Design -> "Convert To PCB"
-![conver to schematic](https://cloud-g1kkox8xj-hack-club-bot.vercel.app/0converttoschematic.gif)
+![conver to schematic](https://cdn.hackclub.com/rescue?url=https://cloud-g1kkox8xj-hack-club-bot.vercel.app/0converttoschematic.gif)
 
 Rotate your components to minimize the rat lines (these subtle blue lines) crossing over each other. It's okay if it happens sometimes, but minimize the amount of times. 
 
-![noRatsCrossing](https://cloud-3ts8mn0bw-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_2.57.23_pm.png)
+![noRatsCrossing](https://cdn.hackclub.com/rescue?url=https://cloud-3ts8mn0bw-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_2.57.23_pm.png)
 
 Then use the Track Tool (W) to begin connecting the rat lines
 
-![connectRats](https://cloud-q6a3ktc2y-hack-club-bot.vercel.app/0connectrats.gif)
+![connectRats](https://cdn.hackclub.com/rescue?url=https://cloud-q6a3ktc2y-hack-club-bot.vercel.app/0connectrats.gif)
 
 ## Getting Artistic 
 
 Now, throw your art into the schematic! This will be on a silk layer, so it will not impact your wiring.
 
-![Make First Pcb](https://cloud-l9r67m3n3-hack-club-bot.vercel.app/0add_in_the_art.gif)
+![Make First Pcb](https://cdn.hackclub.com/rescue?url=https://cloud-l9r67m3n3-hack-club-bot.vercel.app/0add_in_the_art.gif)
 
 You now need to make you art into a silk layer
 
-![makeYellow](https://cloud-pihem7ix9-hack-club-bot.vercel.app/0silklayer.gif)
+![makeYellow](https://cdn.hackclub.com/rescue?url=https://cloud-pihem7ix9-hack-club-bot.vercel.app/0silklayer.gif)
 
 Next, move your components to make them fit your design.
 
-![movedAround](https://cloud-d4z0ripa1-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_3.18.18_pm.png)
+![movedAround](https://cdn.hackclub.com/rescue?url=https://cloud-d4z0ripa1-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_3.18.18_pm.png)
 
 It's time to cut out your board! 
 
-![cut out](https://cloud-7kaunz432-hack-club-bot.vercel.app/0outline.gif)
+![cut out](https://cdn.hackclub.com/rescue?url=https://cloud-7kaunz432-hack-club-bot.vercel.app/0outline.gif)
 
 Now you may have some loose wires or some rat lines that are not connected yet. Connect all of your loose wires to components and fix any of the yellow xs (that means your lines are crossing in a way that will cause a problem)
 
-![Here is a snake](https://cloud-8uy971i40-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_3.45.18_pm.png)
+![Here is a snake](https://cdn.hackclub.com/rescue?url=https://cloud-8uy971i40-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_3.45.18_pm.png)
 
 Boom... now you have a PCB!
 
-![board color](https://cloud-plhykfmfn-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_3.23.48_pm.png)
+![board color](https://cdn.hackclub.com/rescue?url=https://cloud-plhykfmfn-hack-club-bot.vercel.app/0screenshot_2024-03-13_at_3.23.48_pm.png)
 
 You should now go & order this board! 
 

--- a/jams/singles/custom-snowglobe/en-US.md
+++ b/jams/singles/custom-snowglobe/en-US.md
@@ -3,7 +3,7 @@ title: 'Making a Custom Digital Snowglobe'
 description: >  
   This Jam leads participants through a journey of creating their very own custom digital snowglobe that can even react to device motion!
 contributor: 'VelocityDesign'  
-thumbnail: 'https://cloud-lhlq7iz03-hack-club-bot.vercel.app/0snowglobe.gif'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-lhlq7iz03-hack-club-bot.vercel.app/0snowglobe.gif'
 timeEstimate: '60 Min'
 difficulty: 'Intermediate'
 keywords: 'Web, Snowglobe, Snow, website, javascript, HTML, CSS, replit'
@@ -12,28 +12,28 @@ slug: 'custom-snowglobe'
 presentation: 'https://www.figma.com/proto/irzmIKLAgp2DC0Op6LL46d/Snowglobe?type=design&node-id=1-3&t=R9P5nSfR6B0jP1bd-1&scaling=contain&page-id=0%3A1&mode=design'
 presentationPlay: 'https://www.figma.com/file/irzmIKLAgp2DC0Op6LL46d/Snowglobe?type=design&mode=design&t=D4GxfdgxV0G6w8MC-1'
 video: ''
-presentationPDF: 'https://cloud-cgmqkb53u-hack-club-bot.vercel.app/0snowglobe-compressed.pdf'
-notes: 'https://cloud-avh8xhfhk-hack-club-bot.vercel.app/0presentation_notes.pdf'
-poster: 'https://cloud-mura8dz7x-hack-club-bot.vercel.app/0poster.pdf'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-cgmqkb53u-hack-club-bot.vercel.app/0snowglobe-compressed.pdf'
+notes: 'https://cdn.hackclub.com/rescue?url=https://cloud-avh8xhfhk-hack-club-bot.vercel.app/0presentation_notes.pdf'
+poster: 'https://cdn.hackclub.com/rescue?url=https://cloud-mura8dz7x-hack-club-bot.vercel.app/0poster.pdf'
 ---
 
-> For the Code Snippets PDF, [click here.](https://cloud-gdufd98x3-hack-club-bot.vercel.app/0code_snippets.pdf)
+> For the Code Snippets PDF, [click here.](https://cdn.hackclub.com/rescue?url=https://cloud-gdufd98x3-hack-club-bot.vercel.app/0code_snippets.pdf)
 
 # Introduction
 Winter is objectively the best season of the year. Hot cocoa, pine trees, family tradition, sledding, and, most importantly, snow, are all favourites from this cozy season. However, winter doesn't last forever, and snow melts, much to the dismay of every five-year-old with a snowman. But, we humans have made a solution... snowglobes!
 
-![https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cloud-fcssxnb6l-hack-club-bot.vercel.app/6snow_doge.png)]
+![https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/6snow_doge.png)]
 
 So much snow in a small sphere?!? What much more could a person want?
 
-![https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cloud-fcssxnb6l-hack-club-bot.vercel.app/7power_graph.png)
+![https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/7power_graph.png)
 > It's scientifically proven!
 
 So, how would you like to create your own, virtual, shareable snowglobe? (I guess you don't have a choice at this point because, spoiler alert, you are doing that right about now...)
 
 ## What We're Making
 
-![https://cloud-782rtf1du-hack-club-bot.vercel.app/0ezgif.com-resize.gif](https://cloud-782rtf1du-hack-club-bot.vercel.app/0ezgif.com-resize.gif)
+![https://cdn.hackclub.com/rescue?url=https://cloud-782rtf1du-hack-club-bot.vercel.app/0ezgif.com-resize.gif](https://cdn.hackclub.com/rescue?url=https://cloud-782rtf1du-hack-club-bot.vercel.app/0ezgif.com-resize.gif)
 
 In this jam, we'll be making a custom, digital snowglobe (as implied by the title!) You'll be able to choose the background, particles, or even the music. [Here's a live demo of what we're building.](https://snowglobe.judahbrown.dev/)
 
@@ -209,7 +209,7 @@ Finally, we'll add the function to handle shaking activation!
 ```
 
 ### ↕ Choices, choices
-Now, time to tie it all together! tsParticles can load particle configuration in a number of ways, but one of the easiest is to load it from a `.json` file. Go ahead and download [this default snow configuration](https://cloud-66d7j3kh5-hack-club-bot.vercel.app/0particles.json) and place it in your website root as `particles.json`. You can customize these values later.
+Now, time to tie it all together! tsParticles can load particle configuration in a number of ways, but one of the easiest is to load it from a `.json` file. Go ahead and download [this default snow configuration](https://cdn.hackclub.com/rescue?url=https://cloud-66d7j3kh5-hack-club-bot.vercel.app/0particles.json) and place it in your website root as `particles.json`. You can customize these values later.
 
 Under the `calculateAcceleration()` function, add the command `tsParticles.load()`, which allows us to load the configuration. This command takes two inputs, element ID and configuration. Our element ID is the ID of the element where we want the particles to appear, and our configuration is the path to our config file, `particles.json`.
 
@@ -271,7 +271,7 @@ And, that's all!
 At this point, you have a nice, amazing snowglobe. Congratulations 🎉
 However, it's looking like all of these snowglobes are the same...
 
-![https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cloud-fcssxnb6l-hack-club-bot.vercel.app/8identical_snowglobes.png)
+![https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/8identical_snowglobes.png)
 
 Let's fix that by spicing them up a bit!
 
@@ -280,7 +280,7 @@ Let's fix that by spicing them up a bit!
 ### Adding an Image
 Adding an image is super simple! If you don't have an image you'd like to use already, you can find one on a free service like [Unsplash!](https://unsplash.com/) 
 
-![https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cloud-fcssxnb6l-hack-club-bot.vercel.app/3mountains.png)
+![https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/3mountains.png)
 > For example, this one.
 
 Download the image and add it to the website folder (Err- upload it to your repl!) For simplicity, let's rename the file to `background.jpg` (or `.png`, etc.) Now, go into the CSS for the `#snowglobe` element. Let's change up that background...
@@ -293,13 +293,13 @@ Download the image and add it to the website folder (Err- upload it to your repl
 
 Now, if you want to change up the position of the image within the globe, just change `center` in `center/cover`  to another location such as `right`, `top`, or `bottom`.
 
-![https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cloud-fcssxnb6l-hack-club-bot.vercel.app/4picture_globe.png)
+![https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/4picture_globe.png)
 > Hurrah, cool mountains!
 
 ### Adding a Gradient
 To keep it simple, you can use a tool like [cssgradient.io](https://cssgradient.io/) to generate a cool gradient background. Once you're done, all you need to do is copy the part that starts with `linear-gradient`.
 
-![https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cloud-fcssxnb6l-hack-club-bot.vercel.app/2gradient_highlighted.png)
+![https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/2gradient_highlighted.png)
 > Just the highlighted part!
 
 Next, go into the CSS for the `#snowglobe` element. Let's change up that background...
@@ -311,7 +311,7 @@ Next, go into the CSS for the `#snowglobe` element. Let's change up that backgro
 }
 ```
 
-![https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cloud-fcssxnb6l-hack-club-bot.vercel.app/5gradient_globe.png)
+![https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/](https://cdn.hackclub.com/rescue?url=https://cloud-fcssxnb6l-hack-club-bot.vercel.app/5gradient_globe.png)
 > A cool sunset made with the gradient `linear-gradient(4deg, rgba(134, 100, 0, 1) 0%, rgba(121, 9, 9, 1) 32%, rgba(4, 0, 70, 1) 100%)`
 
 If you want an extra cool challenge, try animating it! See [the section on animation above](#### Bonus: A shake animation!) and try to figure it out for yourself!
@@ -361,7 +361,7 @@ At this point, you have a cool snowglobe that's custom to you. Now, you can make
 
 In order to do this, we'll use a web technology called a Progressive Web App (Or, PWA for short.) PWA uses a combination of smaller web technologies, like web manifests that declare your site and its content and service workers that allow your site to cache content and run in the background. All in all, it creates a neat little package for a web app.
 
-To start, download [these assets](https://cloud-osijhtm8u-hack-club-bot.vercel.app/0pwa.zip) and unzip them into the root of your project. If you want, you can generate these assets with a custom icon and color scheme using a tool like [Real Favicon Generator](https://realfavicongenerator.net/), my personal favourite. Now, add the following HTML to the end of your head:
+To start, download [these assets](https://cdn.hackclub.com/rescue?url=https://cloud-osijhtm8u-hack-club-bot.vercel.app/0pwa.zip) and unzip them into the root of your project. If you want, you can generate these assets with a custom icon and color scheme using a tool like [Real Favicon Generator](https://realfavicongenerator.net/), my personal favourite. Now, add the following HTML to the end of your head:
 
 ```html
   <!-- PWA Stuff -->

--- a/jams/singles/erc-20-token/en-US.md
+++ b/jams/singles/erc-20-token/en-US.md
@@ -11,9 +11,9 @@ keywords: 'Crypto, Cryptocurrency, Token, ERC-20, Metamask, Endpoint, Solidity, 
 language: 'Solidity'
 presentation: 'https://www.figma.com/file/UFFlwD9kEFmMkygaY8yG3h/Untitled?type=design&node-id=0%3A1&mode=design&t=9UnEZB6EYxvg2aQv-1'
 presentationPlay: 'https://www.figma.com/proto/UFFlwD9kEFmMkygaY8yG3h/Untitled?type=design&node-id=2-2&t=IebotsxN9M6q3Edr-1&scaling=contain&page-id=0%3A1&mode=design'
-presentationPDF: 'https://cloud-fplorbj3h-hack-club-bot.vercel.app/0make_your_own_club_token_w_solidity.pdf'
-notes: 'https://cloud-mrmhmej0t-hack-club-bot.vercel.app/0notes_for_this_jam__for_learner_to_note__jot_down_.pdf'
-poster: 'https://cloud-5bv8lvd9u-hack-club-bot.vercel.app/0red_modern_and_minimalist_crypto_tips_your_story.png'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-fplorbj3h-hack-club-bot.vercel.app/0make_your_own_club_token_w_solidity.pdf'
+notes: 'https://cdn.hackclub.com/rescue?url=https://cloud-mrmhmej0t-hack-club-bot.vercel.app/0notes_for_this_jam__for_learner_to_note__jot_down_.pdf'
+poster: 'https://cdn.hackclub.com/rescue?url=https://cloud-5bv8lvd9u-hack-club-bot.vercel.app/0red_modern_and_minimalist_crypto_tips_your_story.png'
 video: ''
 slug: 'erc-20-token'
 ---
@@ -23,7 +23,7 @@ slug: 'erc-20-token'
 
 What you will end up with:
 
-![Demo](https://cloud-rcnqjs0ni-hack-club-bot.vercel.app/0image.png)
+![Demo](https://cdn.hackclub.com/rescue?url=https://cloud-rcnqjs0ni-hack-club-bot.vercel.app/0image.png)
 
 ## How you will use this as a club?
 
@@ -33,13 +33,13 @@ This guide teaches users how to create their own personalized cryptocurrency tok
 
 <dropdown title="Here are some memes to convey the message:">
 
-![meme](https://cloud-db2kqcawa-hack-club-bot.vercel.app/77tjen8.jpg)
+![meme](https://cdn.hackclub.com/rescue?url=https://cloud-db2kqcawa-hack-club-bot.vercel.app/77tjen8.jpg)
 
-![meme](https://cloud-db2kqcawa-hack-club-bot.vercel.app/67tjep6.jpg)
+![meme](https://cdn.hackclub.com/rescue?url=https://cloud-db2kqcawa-hack-club-bot.vercel.app/67tjep6.jpg)
 
-![meme](https://cloud-db2kqcawa-hack-club-bot.vercel.app/4download__2_.jpg)
+![meme](https://cdn.hackclub.com/rescue?url=https://cloud-db2kqcawa-hack-club-bot.vercel.app/4download__2_.jpg)
 
-![meme](https://cloud-db2kqcawa-hack-club-bot.vercel.app/3download__3_.jpg)
+![meme](https://cdn.hackclub.com/rescue?url=https://cloud-db2kqcawa-hack-club-bot.vercel.app/3download__3_.jpg)
 </dropdown>
 
 ## Why should you even care?
@@ -117,7 +117,7 @@ This guide teaches users how to create their own personalized cryptocurrency tok
 
 14. Scroll to the bottom and click "Add a Network Manually"
 
-![Ss](https://cloud-es32hz2zz-hack-club-bot.vercel.app/0screenshot__74_.png)
+![Ss](https://cdn.hackclub.com/rescue?url=https://cloud-es32hz2zz-hack-club-bot.vercel.app/0screenshot__74_.png)
 
 16. Fill out the form as follows:
     - Network Name: Ethereum Sepolia
@@ -134,7 +134,7 @@ This guide teaches users how to create their own personalized cryptocurrency tok
 
 19. Go to sepoliafaucet.com in your web browser (You're just a few clicks away from being a crypto millionaire! Well, at least in Sepolia. Time to collect those shiny tokens!)
 
-     ![ss](https://cloud-noik0omfz-hack-club-bot.vercel.app/0screenshot__77_.png)
+     ![ss](https://cdn.hackclub.com/rescue?url=https://cloud-noik0omfz-hack-club-bot.vercel.app/0screenshot__77_.png)
 
 21. Paste the copied MetaMask address into the provided field on the Sepolia Faucet website
 
@@ -162,7 +162,7 @@ contract MyToken is ERC20 {
 
 ```
 
-![ss](https://cloud-37tpft686-hack-club-bot.vercel.app/0screenshot__80_.png)
+![ss](https://cdn.hackclub.com/rescue?url=https://cloud-37tpft686-hack-club-bot.vercel.app/0screenshot__80_.png)
 
 ```
 Code explaination:
@@ -199,7 +199,7 @@ _mint is used to set and create an amount of tokens in the blockchain, you can i
 
 28. Wait for the MetaMask popup to appear and accept any prompts that show up (Buckle up, folks! You're about to embark on a digital transaction journey. Fasten your seatbelts and prepare for takeoff!)
 
-    ![ss](https://cloud-qsv7014dp-hack-club-bot.vercel.app/0screenshot__81_.png)
+    ![ss](https://cdn.hackclub.com/rescue?url=https://cloud-qsv7014dp-hack-club-bot.vercel.app/0screenshot__81_.png)
 
 30. Wait for a message or confirmation from MetaMask indicating the successful deployment
 
@@ -213,8 +213,8 @@ _mint is used to set and create an amount of tokens in the blockchain, you can i
 
 34. Paste the copied contract address into the search bar on Etherscan and verify its existence (Let's play detective! Paste the contract address and see if our virtual creation has left its digital footprint on the blockchain.)
 
-    ![ss](https://cloud-jje5y5mxt-hack-club-bot.vercel.app/0screenshot__82_.png)
-    ![ss](https://cloud-jje5y5mxt-hack-club-bot.vercel.app/1screenshot__83_.png)
+    ![ss](https://cdn.hackclub.com/rescue?url=https://cloud-jje5y5mxt-hack-club-bot.vercel.app/0screenshot__82_.png)
+    ![ss](https://cdn.hackclub.com/rescue?url=https://cloud-jje5y5mxt-hack-club-bot.vercel.app/1screenshot__83_.png)
 
 36. Go back to MetaMask (Time to check on your tokens like a dragon guarding its treasure!)
 
@@ -222,13 +222,13 @@ _mint is used to set and create an amount of tokens in the blockchain, you can i
 
 38. Paste the deployed contract's address (same one used in sepolia.etherscan.io) and wait for the form to auto-complete
 
-    ![ss](https://cloud-67bytcbnd-hack-club-bot.vercel.app/0screenshot__85_.png)
+    ![ss](https://cdn.hackclub.com/rescue?url=https://cloud-67bytcbnd-hack-club-bot.vercel.app/0screenshot__85_.png)
 
 40. Continue and wait for the token to be imported
 
 41. You will receive your coins in MetaMask (Cha-ching! It's raining digital coins in your MetaMask wallet. Time to celebrate!)
 
-    ![ss](https://cloud-67bytcbnd-hack-club-bot.vercel.app/1screenshot__86_.png)
+    ![ss](https://cdn.hackclub.com/rescue?url=https://cloud-67bytcbnd-hack-club-bot.vercel.app/1screenshot__86_.png)
 
 ### Personalizing options
 
@@ -242,9 +242,9 @@ _mint is used to set and create an amount of tokens in the blockchain, you can i
 * IMPORTANT STEP - You can rename the Network name to your coins name and ** ADD YOUR (THE PERSON SENDING THE TOKEN) Quicknode http link (step 9) and paste it in the reciever's NEW RPC URL field.
 * then go back your dashboard, click on your coin, click on send, paste the recievers address (step 18) to send it to him! Its that easy!!!!
 
-  ![sending](https://cloud-ago25sz07-hack-club-bot.vercel.app/0how_to_send_tokens.gif)
+  ![sending](https://cdn.hackclub.com/rescue?url=https://cloud-ago25sz07-hack-club-bot.vercel.app/0how_to_send_tokens.gif)
   
-  ![getting](https://cloud-ago25sz07-hack-club-bot.vercel.app/1recieved_tokens.gif)
+  ![getting](https://cdn.hackclub.com/rescue?url=https://cloud-ago25sz07-hack-club-bot.vercel.app/1recieved_tokens.gif)
 
 ### A couple of things as tips or bonus
 * Make sure to give all your addresses right as messing up addresses can ruin literally everything

--- a/jams/singles/glsl-shaders/en-US.md
+++ b/jams/singles/glsl-shaders/en-US.md
@@ -4,7 +4,7 @@ description: >
   In this jam, you'll learn about the Mandelbrot set, and how to render it (and other fractals!) in realtime using ShaderToy.
 contributor: 'NalinPlad'  
 contributorSlackID: 'U03Q06DS8H2'
-thumbnail: 'https://cloud-69nbi0x97-hack-club-bot.vercel.app/00render-min.gif' 
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-69nbi0x97-hack-club-bot.vercel.app/00render-min.gif' 
 timeEstimate: '60 Min'  
 difficulty: 'Advanced'  
 keywords: 'Shaders, GPU, graphics, fractals, art, math' 

--- a/jams/singles/hacker-card/en-US.md
+++ b/jams/singles/hacker-card/en-US.md
@@ -34,19 +34,19 @@ It can be a little bit tricky to get used to, so we made a [very short video](ht
 
 When you go to the website, you should see a screen like this. Click `Sign Up` to create an account, if you don't already have one.
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/8new-project.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/8new-project.png)
 
 Click on the `EasyEDA Designer` button in the Navbar to open up the schematic editor.
 
 Once you've logged in, select `File` > `New` > `Project` to create a new project.
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/8new-project.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/8new-project.png)
 
 This will open up the schematic editor. Some important parts:
 
 - `Library` on the left toolbar: This is where we will search for components and place them into our schematic.
 - `Wiring Tools` panel: We'll be using the wire tool to connect the components together.
 
-![](https://cloud-lagxcclbp-hack-club-bot.vercel.app/3schematic.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lagxcclbp-hack-club-bot.vercel.app/3schematic.png)
 
 ## Placing components into the schematic
 
@@ -59,11 +59,11 @@ For our card, we'll want a capacitor, a resistor, a 2V LED and a NFC chip:
 
 Click the `Library` button to open the parts picker. Search for a part (the part number works best), and make sure `JLCPCB Assembled` is selected. This will make sure we're choosing parts from JLCPCB's parts library, as this is currently Hack Club's Onboard PCB manufacturer.
 
-![](https://cloud-lagxcclbp-hack-club-bot.vercel.app/4searching-for-parts.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lagxcclbp-hack-club-bot.vercel.app/4searching-for-parts.png)
 
 Select the part, then hit the `Place` button to add it to your schematic. Repeat for all 4 of the parts listed above.
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/9parts-on-schematic.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/9parts-on-schematic.png)
 
 > Note: The EasyEDA parts library may not always be helpful when finding parts for your own future projects, so feel free to search the internet for parts and their codes. You can also create your own parts, but that's a bit more advanced.
 
@@ -75,7 +75,7 @@ Note: this is not an actual part, so it doesn't need to be assembled onto the bo
 
 To add the antenna, search for `25X48MM_NFC_ANTENNA` in the Library, and instead of `JLCPCB Assembled`, select `User Contributed`. Select one of the options (check the preview to make sure it looks similar to the one I used here, but most of them should work), and place it on your schematic.
 
-![](https://cloud-lagxcclbp-hack-club-bot.vercel.app/5selecting-antenna.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lagxcclbp-hack-club-bot.vercel.app/5selecting-antenna.png)
 
 ## Wiring up the components
 
@@ -92,7 +92,7 @@ The datasheet says
 
 So we'll connect the capacitor between `VOUT` and GND (the `VSS` pin).
 
-<video src="https://cloud-bfxdnmxrd-hack-club-bot.vercel.app/1wire-tool.mp4" controls="controls" style={{ maxWidth: "480px" }}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-bfxdnmxrd-hack-club-bot.vercel.app/1wire-tool.mp4" controls="controls" style={{ maxWidth: "480px" }}></video>
 
 - The pins `LA` and `LB` are for the antenna, so we'll wire up the antenna between those two pins.
 - > If NTAG I2C also powers the I2C bus, then VCC must be connected to VOUT
@@ -105,7 +105,7 @@ Your schematic should look something like this when completed:
 
 > Note that your schematic may look a bit different from mine -- that's okay! As long as the connections are the same, it should work. So feel free to experiment with different layouts, maybe keep the antenna on the right or change the position of LEDs and resistors? It's up to you!
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/3completed-schematic.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/3completed-schematic.png)
 
 > Friendly reminder to save (`command + s` or `control + s`) your work! You can also click `Project` > `Save Project` to save your schematic. 
 
@@ -117,7 +117,7 @@ Now that the schematic is complete, we can start designing the actual PCB. In th
 
 To convert the schematic into a PCB design file, click `Design` > `Convert Schematic to PCB`. You may get a warning about unfinished nets -- this is fine, just click "No, Keep Going."
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/5convert-schematic-to-pcb.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/5convert-schematic-to-pcb.png)
 
 This will open up the PCB editor, as well as a popup window to specify the board's dimensions. (If the popup window doesn't show up for any reason, you can find it through `Tools` > `Set Board Outline`.)
 
@@ -128,13 +128,13 @@ Here are the dimensions I'll be using, but feel free to make your business card 
 - Height: 50.8mm
 - Radius: 4mm
 
-![](https://cloud-lagxcclbp-hack-club-bot.vercel.app/6set-board-outline.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lagxcclbp-hack-club-bot.vercel.app/6set-board-outline.png)
 
 ## Functionality: Making a working PCB card
 
 Once you set the board outline, you should see something like the image below. There's the outline of the board in pink, a bunch of components in red, and some thin blue lines connecting the components. Let's talk about what these are, and what the colors mean!
 
-![](https://cloud-lagxcclbp-hack-club-bot.vercel.app/0pcb-editor.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lagxcclbp-hack-club-bot.vercel.app/0pcb-editor.png)
 
 ### Layers
 
@@ -145,7 +145,7 @@ A PCB like a sandwich -- it's made up of many different layers. We're designing 
 - On top of the copper layers are **soldermask** layers. This is what gives PCBs their color -- common soldermask colors are green or black, but white, purple, blue, red, yellow, and more are also possible. Soldermask is added to the entire surface of the board (both the top and the bottom) by default. If you want to **remove** the soldermask (which will reveal the copper underneath), use the `TopSolderMaskLayer` or `BottomSolderMaskLayer` (for the top and bottom of the board, respectively).
 - On top of the soldermask layers are **silkscreen** layers. Silkscreen is usually white, and is generally used to label and identify components, but we'll be using it for ✨ PCB art ✨. We can use this to add contact info, a QR code, or even some illustrations to our business card. In EasyEDA, silkscreen is added on the `TopSilkLayer` and `BottomSilkLayer`.
 
-![](https://cloud-lagxcclbp-hack-club-bot.vercel.app/1pcb-layers.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lagxcclbp-hack-club-bot.vercel.app/1pcb-layers.png)
 
 ### Components
 
@@ -159,7 +159,7 @@ Some helpful tips:
 
 Drag the components around until you're happy with the placement. Here's what mine looks like, but don't copy it directly; almost anything will work!
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/4components-placed.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/4components-placed.png)
 
 ### Routing traces
 
@@ -167,15 +167,15 @@ Now, we have a bunch of components on the card. If we were to have the card manu
 
 It's best practice to manually route your traces, using the first button in the PCB tools panel: the `Track` tool.
 
-![](https://cloud-lagxcclbp-hack-club-bot.vercel.app/2pcb-tools.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lagxcclbp-hack-club-bot.vercel.app/2pcb-tools.png)
 
 However, to speed up the jam a bit, we'll be using EasyEDA's auto-router. Select `Route` > `Auto Route...` and click `Run` to watch the magic happen...
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/0auto-router.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/0auto-router.png)
 
 ...Except, it seems like the magical autorouter 🪄 wasn't 100% successful :(. We'll finish up the last bit with some manual routing.
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/1autorouter-results.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/1autorouter-results.png)
 
 In my case, the autorouter was able to connect most of the components, but there's still one thin blue line (representing an unrouted connection). Can you find it?
 
@@ -185,7 +185,7 @@ Zooooming in, we see that it's between the antenna loop and pin #8 on the NFC ch
 2. On the right sidebar, set `Routing Conflict` to `Ignore`. This step is generally not needed (for normal manual routing), but there's a small issue with the footprints that makes it necessary here.
 3. Click between the two pads that need to be connected. The thin blue line should disappear, and a red trace should connect the two pads.
 
-<video src="https://cloud-bfxdnmxrd-hack-club-bot.vercel.app/0manual-routing.mp4" controls="controls" style={{ maxWidth: "480px" }}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-bfxdnmxrd-hack-club-bot.vercel.app/0manual-routing.mp4" controls="controls" style={{ maxWidth: "480px" }}></video>
 
 Now, your PCB card is functional. Woooo! 🎉
 
@@ -194,17 +194,17 @@ _WARNING: Make sure your design has no short circuits_
            Short circuits is a circuits that allow current to travel along an unintended path. 
 
           Heres a simple example:
-          ![](https://cloud-m5qt0nitx-hack-club-bot.vercel.app/0image.png)
+          ![](https://cdn.hackclub.com/rescue?url=https://cloud-m5qt0nitx-hack-club-bot.vercel.app/0image.png)
           In this circuit, the path of least resistance is the path in red. It flows through the led and the battery, thus the LED will light up
 
           However, in this circuit:
-          ![](https://cloud-abtjpv714-hack-club-bot.vercel.app/0image.png)
+          ![](https://cdn.hackclub.com/rescue?url=https://cloud-abtjpv714-hack-club-bot.vercel.app/0image.png)
           The wires cross paths and make a new path of least resistance, that does not go through the LED. This causes the led to not light up.
         
 </Dropdown>
  <Dropdown title="We don't want that! How can I see if I have a short circuit?">  
           The first thing to check for is if you have any traces(wires) that intersect or overlap, such as these 2 examples
-          ![](https://cloud-5hfwliwe8-hack-club-bot.vercel.app/0image.png) ![](https://cloud-2hhbo4z62-hack-club-bot.vercel.app/0image.png)
+          ![](https://cdn.hackclub.com/rescue?url=https://cloud-5hfwliwe8-hack-club-bot.vercel.app/0image.png) ![](https://cdn.hackclub.com/rescue?url=https://cloud-2hhbo4z62-hack-club-bot.vercel.app/0image.png)
           If you don't see any of these, you should be fine. However, if you want to be extra careful, do a Design Rule Check, by going to Design -> Check DRC
           
           Most of the errors are not actual issues, but if you click through them and find something that unsure of, consider asking around on the #Onboard channel on slack.
@@ -213,19 +213,19 @@ _WARNING: Make sure your design has no short circuits_
   You should check to see if there is a different path the wire could take so it doesn't intersect, kind of like the battery and led example from above. If this is not   possible, then don't worry. This is why our board as multiple layers!
 
 The PCB below has many shorts
-![](https://cloud-nggsler3h-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-nggsler3h-hack-club-bot.vercel.app/0image.png)
 The solution is to move the wire from the top layer to the bottom layer!
 First, select the wire you want to move
-![](https://cloud-grp5qt7qm-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-grp5qt7qm-hack-club-bot.vercel.app/0image.png)
 Next, in the top right, select TopLayer, and change it to BottomLayer
-![](https://cloud-ny3wmd3c4-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-ny3wmd3c4-hack-club-bot.vercel.app/0image.png)
 The wire should turn blue, or another color.
 
 The last step is to change the pads to multilayer. First select the area where the wire and component intersect
-![](https://cloud-hzdm59xgm-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-hzdm59xgm-hack-club-bot.vercel.app/0image.png)
 
 Select top layer, and change it to multilayer
-![](https://cloud-k7tdushgc-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-k7tdushgc-hack-club-bot.vercel.app/0image.png)
 
 Finnally, repeat for the other pad. 
 
@@ -233,7 +233,7 @@ Finnally, repeat for the other pad.
 
 Remember to save your progress! We can check out a preview by clicking the `3D` button in the top toolbar. Hmmm... doesn't look like a business card yet. Let's add some personality to it!
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/2card-preview.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/2card-preview.png)
 
 ## Aesthetics: Personalizing your card
 
@@ -243,11 +243,11 @@ We'll mostly be using the silkscreen layer to add our information and designs. S
 
 In the PCB Tools panel, select the `Text` tool. If you want to make it a business card, you can add your name and contact info -- or add any other text you want. Select the text object you just placed, and change the font, line width, and size in the right sidebar.
 
-![](https://cloud-lagxcclbp-hack-club-bot.vercel.app/8text-properties.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lagxcclbp-hack-club-bot.vercel.app/8text-properties.png)
 
 Drag the text to where you want it on your board. Here, I've added my name, website, and GitHub. If you need ideas: you can add your email, phone number, or other social media handles.
 
-![](https://cloud-lagxcclbp-hack-club-bot.vercel.app/7text-added.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lagxcclbp-hack-club-bot.vercel.app/7text-added.png)
 
 ### Adding a QR Code
 
@@ -255,7 +255,7 @@ EasyEDA also supports importing images! I'll use this to add a QR Code that link
 
 Just like Text objects, you can select the image to modify the properties (width, height, etc.) on the right sidebar.
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/6import-image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/6import-image.png)
 
 Note: we've been placing everything on the yellow `TopSilkLayer`. This means that they will all appear on the top side of our board. If you want to add anything to the bottom, use the green `BottomSilkLayer`! Keep in mind that the bottom layers of the board are a top-down, see through view, which is essentially flipped -- use the 3D viewer to check that all your text and images are oriented correctly.
 
@@ -270,7 +270,7 @@ Here are some examples -- try incorporating these techniques into your board.
 - **Textured, or with slight color variation**: add your object to only the `TopLayer` or `BottomLayer`. Without removing the soldermask, the copper will still be covered by the soldermask, but it may slightly lighten the soldermask color and will create a textured feel.
 - **Translucent yellow** (color of the FR-4 material): add our object to only the `TopSolderMaskLayer` or `BottomSolderMaskLayer`. This will remove the soldermask on the object, revealing the yellow FR-4 material underneath. This technique is useful for allowing LEDs to shine from one side of the board to the other, or just for adding another color to your design.
 
-![](https://cloud-qega55fyl-hack-club-bot.vercel.app/7layer-effects.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-qega55fyl-hack-club-bot.vercel.app/7layer-effects.png)
 
 ## Turn your design... into an actual card!
 

--- a/jams/singles/kaboom-game/en-US.md
+++ b/jams/singles/kaboom-game/en-US.md
@@ -4,14 +4,14 @@ description: >
   In this Jam, you'll be designing and creating a fun platformer-style game and sharing it with your friends.
 contributor: 'ajs256'
 contributorSlackID: 'U04MDFEBL2U'
-thumbnail: 'https://cloud-5kma4td0d-hack-club-bot.vercel.app/0kaboom.gif'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-5kma4td0d-hack-club-bot.vercel.app/0kaboom.gif'
 timeEstimate: '30 Min'  
 difficulty: 'Intermediate'  
 keywords: 'Web, Game, js, JavaScript, glitch, kaboom, gamedev' 
 language: 'JavaScript'  
 presentation: "https://www.figma.com/file/fUIpjYIAnybmQXUOr8rEPn/KaboomJam?type=design&node-id=0%3A1&mode=design&t=HnYTGbk8JkUTZmWg-1" 
 presentationPlay: "https://www.figma.com/proto/fUIpjYIAnybmQXUOr8rEPn/KaboomJam?type=design&node-id=1-2&t=phUMnwxbFt7UStva-1&scaling=contain&page-id=0%3A1&mode=design" 
-presentationPDF: "https://cloud-93xagowus-hack-club-bot.vercel.app/0kaboomjam__1_.pdf" 
+presentationPDF: "https://cdn.hackclub.com/rescue?url=https://cloud-93xagowus-hack-club-bot.vercel.app/0kaboomjam__1_.pdf" 
 notes: "" 
 poster: "" 
 video: "" 
@@ -20,7 +20,7 @@ slug: 'kaboom-game'
 
 
 Hello!! In this Jam, you will be designing and building a web game. When you're all done, it'll look a bit like this:
-![A demonstration of a completed platformer game](https://cloud-4p2y0vzmm-hack-club-bot.vercel.app/0screen_recording_2023-08-04_at_11.06.53_am.gif)
+![A demonstration of a completed platformer game](https://cdn.hackclub.com/rescue?url=https://cloud-4p2y0vzmm-hack-club-bot.vercel.app/0screen_recording_2023-08-04_at_11.06.53_am.gif)
 
 ## So how are we gonna do this?
 Here are the steps we'll go through to build your own game:
@@ -35,7 +35,7 @@ First, let's get started on [🎏 Glitch](https://glitch.com).
            Glitch is a site that makes it super simple to build web apps. You can code in your browser and see your results live.
 </Dropdown>
 1. Go to [glitch.com](https://glitch.com) and click `Sign Up`.
-   ![Glitch.com's header, with an arrow pointing to the Sign Up button](https://cloud-ic6sx4m6w-hack-club-bot.vercel.app/0scr-20230714-psiv-3.png)
+   ![Glitch.com's header, with an arrow pointing to the Sign Up button](https://cdn.hackclub.com/rescue?url=https://cloud-ic6sx4m6w-hack-club-bot.vercel.app/0scr-20230714-psiv-3.png)
 2. Choose how you'd like to sign up - you can use a GitHub account or a Google account, or if you don't have either, click `Email Magic Link` and you'll get a link and code in your email. 
 3. Either click the link in the email or enter the code from the message in your browser.
 4. Wahoo! You're ready to code!
@@ -50,7 +50,7 @@ Before we go any further, let's take a look at the structure of a Kaboom game.
 kaboom()
 ```
 Every Kaboom game's code will start with this - it initializes the library and gets everything set up. Here's what it looks like:
-![A blank checkerboard canvas](https://cloud-6n8dlncke-hack-club-bot.vercel.app/0image.png)
+![A blank checkerboard canvas](https://cdn.hackclub.com/rescue?url=https://cloud-6n8dlncke-hack-club-bot.vercel.app/0image.png)
 
 Pretty boring. Let's get some action going!
 ```js
@@ -65,7 +65,7 @@ add([
 ])
 ```
 This adds a sprite to the screen. 
-![The same background, but now there's a frog-bean-like sprite on it](https://cloud-65jcy7vy5-hack-club-bot.vercel.app/0image.png)
+![The same background, but now there's a frog-bean-like sprite on it](https://cdn.hackclub.com/rescue?url=https://cloud-65jcy7vy5-hack-club-bot.vercel.app/0image.png)
 
 Right now, it doesn't do much. Let's change that!
 ```js
@@ -101,7 +101,7 @@ Now, head back to your code. You'll notice I've left a comment in the code with 
            There's a place in the code where the level is laid out with symbols. Can you try to add more?
 </Dropdown>
 Once you're done, your game should look a bit like this:
-![a screenshot of a platformer game with a wider platform and more coins](https://cloud-7rnuby5u8-hack-club-bot.vercel.app/0image.png)
+![a screenshot of a platformer game with a wider platform and more coins](https://cdn.hackclub.com/rescue?url=https://cloud-7rnuby5u8-hack-club-bot.vercel.app/0image.png)
 
 > Psst.. here's a tip. Hit <kbd>F1</kbd>. See all those blue boxes? Those are the collision areas of each object in your game. Now hover over one of those objects. Now you can see every object's components! It's a bit like those [x-ray specs](https://en.wikipedia.org/wiki/X-ray_specs) that there used to be ads for in comic books, but it actually works. 
 > 
@@ -173,4 +173,4 @@ Now that you've made the perfect game, it's time to let others play it. Just fol
 5. Click the `Edit project` button to get back to coding.
 
 To get a link that your friends can use to play your game, click the big purple `Share` button at the top, then copy the `Live site` link.
-![A screenshot of Glitch's share dialog with the "Live site" link highlighted](https://cloud-mmr3sh0b9-hack-club-bot.vercel.app/0image.png)
+![A screenshot of Glitch's share dialog with the "Live site" link highlighted](https://cdn.hackclub.com/rescue?url=https://cloud-mmr3sh0b9-hack-club-bot.vercel.app/0image.png)

--- a/jams/singles/onboard-grant/en-US.md
+++ b/jams/singles/onboard-grant/en-US.md
@@ -36,7 +36,7 @@ This is a shortened version of the full [submission instructions for the grant](
 
 To follow the repo for updates and show you're participating, click the "star" button on the [`hackclub/onboard`](https://github.com/hackclub/OnBoard/) repo.
 
-![Star the OnBoard repo](https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/3star-repo.png)
+![Star the OnBoard repo](https://cdn.hackclub.com/rescue?url=https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/3star-repo.png)
 
 ## 1. Join the Slack! 
 
@@ -54,29 +54,29 @@ Upload your Gerber files to JLCPCB.com and add them to you cart. Once completed,
 
 Fork the [`onboard`](https://github.com/hackclub/OnBoard/) repo! This is the where you'll add your project files and eventually PR from!
 
-![Fork the OnBoard repo](https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/5onboard-fork.png)
+![Fork the OnBoard repo](https://cdn.hackclub.com/rescue?url=https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/5onboard-fork.png)
 
 ## 4. Add Your Design to Your Project Repo
 
 From your fork of `OnBoard`, create a folder with your project name under `OnBoard/projects`. To do this, go to the projects folder and click `Create new file`.
 
-![Projects folder](https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/2projects.png)
+![Projects folder](https://cdn.hackclub.com/rescue?url=https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/2projects.png)
 
-![Create new file](https://cloud-fw3ggo1g3-hack-club-bot.vercel.app/0add-file.png)
+![Create new file](https://cdn.hackclub.com/rescue?url=https://cloud-fw3ggo1g3-hack-club-bot.vercel.app/0add-file.png)
 
 Then in the box labeled `name your file...`, type in `PROJECT_NAME/README.md`. This creates a README file under a folder called named after your project.
 
-![Creating a folder](https://cloud-fw3ggo1g3-hack-club-bot.vercel.app/3creating-a-folder.png)
+![Creating a folder](https://cdn.hackclub.com/rescue?url=https://cloud-fw3ggo1g3-hack-club-bot.vercel.app/3creating-a-folder.png)
 
 After this, copy and paste the contents of [`TEMPLATE.md`](./projects/!Template/TEMPLATE.md?plain=1) into the text editor and fill it out!
 
-![Paste in TEMPLATE.md](https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/1paste-in-template.png)
+![Paste in TEMPLATE.md](https://cdn.hackclub.com/rescue?url=https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/1paste-in-template.png)
 
 Once your done, press the big green `Commit changes` button to save!
 
 With your README filled out, head over to add files to begin uploading your Gerber, design files, and screen shot of vendor approval.
 
-![Upload gerber files](https://cloud-fw3ggo1g3-hack-club-bot.vercel.app/1adding-gerbers.png)
+![Upload gerber files](https://cdn.hackclub.com/rescue?url=https://cloud-fw3ggo1g3-hack-club-bot.vercel.app/1adding-gerbers.png)
 
 In all, you should have the following files under your project folder:
 - [ ] `README.md`: A filled out [`TEMPLATE.md`](./projects/!Template/TEMPLATE.md?plain=1), renamed to `README.md`.
@@ -97,14 +97,14 @@ If you have all the above, you're done with this step!
 
 Once you've uploaded your files, you can merge them to the main repo through a pull request! Under the contribute tab of your forked repo, click the big green `Open pull request`.
 
-![Open a PR](https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/0open-pr.png)
+![Open a PR](https://cdn.hackclub.com/rescue?url=https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/0open-pr.png)
 
 That will bring you to the main repo, where you'll initiate a pull request. All you need to do is to follow the checklist. Then, we'll review your PR, and you'll be off to the races!
-![Submission checklist](https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/4submission-checklist.png)
+![Submission checklist](https://cdn.hackclub.com/rescue?url=https://cloud-j2h1ajlmt-hack-club-bot.vercel.app/4submission-checklist.png)
 
 
 ## 6. Ship it!
 
 Post photos of your board in [`#onboard`](https://hackclub.slack.com/archives/C056AMWSFKJ)! We can't wait to see what you make!
 
-![John sharing PCB](https://cloud-fw3ggo1g3-hack-club-bot.vercel.app/4john-sharing-pcb.png)
+![John sharing PCB](https://cdn.hackclub.com/rescue?url=https://cloud-fw3ggo1g3-hack-club-bot.vercel.app/4john-sharing-pcb.png)

--- a/jams/singles/online-store/en-US.md
+++ b/jams/singles/online-store/en-US.md
@@ -4,21 +4,21 @@ description: >
   In this jam, you'll be designing your own online store with Figma! In the next jam, we'll be using the Shopify API to turn this into a real store.
 contributor: 'ryanchou-dev'
 contributorSlackID: 'U033ER629RD'
-thumbnail: 'https://cloud-hlz9l0kzh-hack-club-bot.vercel.app/0000image__3___1__50.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-hlz9l0kzh-hack-club-bot.vercel.app/0000image__3___1__50.webp'
 timeEstimate: '45 Min'
 difficulty: 'Easy'
 keywords: 'Design, Figma, website, store, design, ux, ui'
 language: 'Figma'
 presentation: 'https://www.figma.com/file/ZZtBSywMbFgI8T3NWVWXP7/Online-Store-Odyssey?type=design&node-id=8%3A2&mode=design&t=p3WdMPuooBnKpTcP-1'
 presentationPlay: 'https://www.figma.com/proto/ZZtBSywMbFgI8T3NWVWXP7/Online-Store-Odyssey?page-id=0%3A1&type=design&node-id=8-2&viewport=171%2C208%2C0.07&t=1T2UYUSbx8HOPyTG-1&scaling=contain&mode=design'
-presentationPDF: 'https://cloud-mhlmx28h4-hack-club-bot.vercel.app/0online_store_odyssey-min.pdf'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-mhlmx28h4-hack-club-bot.vercel.app/0online_store_odyssey-min.pdf'
 notes: ''
-poster: 'https://cloud-cqx4mk7nt-hack-club-bot.vercel.app/0online-store-poster.pdf'
+poster: 'https://cdn.hackclub.com/rescue?url=https://cloud-cqx4mk7nt-hack-club-bot.vercel.app/0online-store-poster.pdf'
 video: ''
 slug: 'online-store'
 ---
 
-<video controls style={{width: "400px"}}> <source src="https://cloud-opkznq4e6-hack-club-bot.vercel.app/1store_preview.mp4" type="video/mp4" /></video>
+<video controls style={{width: "400px"}}> <source src="https://cdn.hackclub.com/rescue?url=https://cloud-opkznq4e6-hack-club-bot.vercel.app/1store_preview.mp4" type="video/mp4" /></video>
 
 [Sample Figma Design](https://www.figma.com/file/R0x2u5Z0n1wcOAbVVekcei/The-Cow-Charm?type=design&node-id=34%3A423&mode=design&t=68QuGZqGJfs2QT92-1)
 [Interactive Demo](https://www.figma.com/proto/R0x2u5Z0n1wcOAbVVekcei/The-Cow-Charm?page-id=34%3A423&type=design&node-id=34-507&viewport=535%2C362%2C0.09&t=RaHKT5mf6K7wXh1B-1&scaling=scale-down&starting-point-node-id=34%3A507&mode=design)
@@ -68,11 +68,11 @@ Head over to [figma.com](https://www.figma.com/) and create an account! Afterwar
 
 You should be instantly booted into a new design file!
 
-![Figma New File](https://cloud-opkznq4e6-hack-club-bot.vercel.app/0figma_new_file.png)
+![Figma New File](https://cdn.hackclub.com/rescue?url=https://cloud-opkznq4e6-hack-club-bot.vercel.app/0figma_new_file.png)
 
 <Dropdown title="Not there?">
 If you're redirected to the dashboard instead, just click the **+ New Design File** button!
-<video controls style={{width: "400px"}}> <source src="https://cloud-n2adyd9na-hack-club-bot.vercel.app/0file_from_dashboard.mp4" type="video/mp4" /></video>
+<video controls style={{width: "400px"}}> <source src="https://cdn.hackclub.com/rescue?url=https://cloud-n2adyd9na-hack-club-bot.vercel.app/0file_from_dashboard.mp4" type="video/mp4" /></video>
 </Dropdown>
 
 If you're working with a team, click the Share button in the top right and add your groupmates' emails with "Edit" permissions!
@@ -96,19 +96,19 @@ Okay! So, let's go over the structure of the Figma editor.
 
 ---
 
-![Left Sidebar](https://cloud-p4lmdd3r0-hack-club-bot.vercel.app/0pasted_image_20230716011036.png)
+![Left Sidebar](https://cdn.hackclub.com/rescue?url=https://cloud-p4lmdd3r0-hack-club-bot.vercel.app/0pasted_image_20230716011036.png)
 
 ### Left Sidebar
 
 Here, you'll keep track of the current objects in your design (text, shapes, images), and be able to access assets & pages (we'll go over this later).
 
-![Toolbar](https://cloud-i2t8xhz0p-hack-club-bot.vercel.app/0pasted_image_20230716011117.png)
+![Toolbar](https://cdn.hackclub.com/rescue?url=https://cloud-i2t8xhz0p-hack-club-bot.vercel.app/0pasted_image_20230716011117.png)
 
 ### Toolbar
 
 Situated at the top of your screen, this contains every tool you need to start designing, we'll break them down below :)).
 
-![Right Sidebar](https://cloud-i2t8xhz0p-hack-club-bot.vercel.app/1pasted_image_20230716011129.png)
+![Right Sidebar](https://cdn.hackclub.com/rescue?url=https://cloud-i2t8xhz0p-hack-club-bot.vercel.app/1pasted_image_20230716011129.png)
 
 ### Right Sidebar
 
@@ -122,7 +122,7 @@ Figma relies on a layered system of groups. Think about it like you're stacking 
 
 The foundational element for your designs is called a "frame"! It acts like a top-level container for your content. We normally set these to the dimensions of a target device to see what our design might look like on it.
 
-![](https://cloud-ki7xeojmd-hack-club-bot.vercel.app/0frame.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-ki7xeojmd-hack-club-bot.vercel.app/0frame.gif)
 
 ### Group
 
@@ -130,7 +130,7 @@ A group combines related objects together. This is a temporary union that helps 
 
 You can group a selection of layers together with `Ctrl + G`!
 
-![](https://cloud-8utwa7bc9-hack-club-bot.vercel.app/0group.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-8utwa7bc9-hack-club-bot.vercel.app/0group.gif)
 
 ### Layers
 
@@ -142,7 +142,7 @@ Let's have a quick rundown of the tools we'll be using in our design.
 
 Your workshop host should have given you a cheat sheet for Figma's tools; this is your chance to read through it!
 
-You can view the digital copy [here](https://cloud-brvsdgazn-hack-club-bot.vercel.app/0figma_tools.pdf)
+You can view the digital copy [here](https://cdn.hackclub.com/rescue?url=https://cloud-brvsdgazn-hack-club-bot.vercel.app/0figma_tools.pdf)
 
 **Phew!** That was a lot of content. Like I said earlier, feel free to come back and review :D
 
@@ -160,11 +160,11 @@ Take this time to think about the name of your corporation and the products you 
 
 Let's give your project an awesome name! Click into the area which says "Untitled" and give it a name of your choosing (you can change this at any time).
 
-![Name your Project](https://cloud-4m7ljqmox-hack-club-bot.vercel.app/0image.png)
+![Name your Project](https://cdn.hackclub.com/rescue?url=https://cloud-4m7ljqmox-hack-club-bot.vercel.app/0image.png)
 
 Next, we'll make a frame for the landing page of our website. We'll do this by clicking the hashtag-esque button on the navbar, and clicking **Desktop > Macbook Pro 16"** as our size.
 
-<video controls style={{width: "400px"}}> <source src="https://cloud-hivp3jiyp-hack-club-bot.vercel.app/02023-07-15_21-19-10.mp4" type="video/mp4"/> </video>
+<video controls style={{width: "400px"}}> <source src="https://cdn.hackclub.com/rescue?url=https://cloud-hivp3jiyp-hack-club-bot.vercel.app/02023-07-15_21-19-10.mp4" type="video/mp4"/> </video>
 
 Note that you can always extend the height of the frame as you need.
 
@@ -177,7 +177,7 @@ Can you believe it? You've created your first layer in Figma. 🎉
 Inside your frame, we'll create a _text object_! Once the tool is selected, click anywhere in your frame to create a text box. You may type whatever you'd like here.
 
 wait a minute...
-![Text is too small naurr](https://cloud-6gf9bcrd6-hack-club-bot.vercel.app/0pasted_image_20230716031051.png)
+![Text is too small naurr](https://cdn.hackclub.com/rescue?url=https://cloud-6gf9bcrd6-hack-club-bot.vercel.app/0pasted_image_20230716031051.png)
 
 What do you think we should do?
 
@@ -200,19 +200,19 @@ Let's try adding stars to our page. We can do this by selecting the **Star Tool*
 #### Quiz Time!
 
 <Dropdown title="Try to find these properties yourself! (expand for solution)">
-![Needed Properties](https://cloud-6fotdvxns-hack-club-bot.vercel.app/0pasted_image_20230716203619_480.png)
+![Needed Properties](https://cdn.hackclub.com/rescue?url=https://cloud-6fotdvxns-hack-club-bot.vercel.app/0pasted_image_20230716203619_480.png)
 </Dropdown>
 
 Now, I'll make the background black, text white, and change the color and size of the stars!
-![Initial background](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/0pasted_image_20230718011242.png)
+![Initial background](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/0pasted_image_20230718011242.png)
 
 I want the background to resemble a dark sky with a bright moon, so I'll set it to a gradient with dark shades of purple. You can find the settings of the **Fill Color**.
 
-![Gradient](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/1pasted_image_20230718011436.png)
+![Gradient](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/1pasted_image_20230718011436.png)
 
 It's time to create the ✨ charm ✨! I'll make a Circle with the **Ellipse Tool** and import the images I want to use for the design.
 
-![First charm](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/2pasted_image_20230718011702.png)
+![First charm](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/2pasted_image_20230718011702.png)
 
 It's starting to come together! It would be really awesome to have it drop down from the top of the screen, but I'm not sure how to create a string.
 
@@ -224,7 +224,7 @@ It's starting to come together! It would be really awesome to have it drop down 
 > I think I'll stick with the **Line** tool, thanks for your help!
 
 This is cool, but something seems a bit off.
-![String](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/3pasted_image_20230718012123.png)
+![String](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/3pasted_image_20230718012123.png)
 
 There isn't a hole for the string to go through!! It would be easy to just use another circle to indicate the hole, but the gradient background makes it hard to replicate.
 
@@ -234,11 +234,11 @@ If only, we could cut a hole in the circle...
 
 Let's first create a circle to designate the hole, and then select both the charm and the circle destined to be a hole on top of it.
 
-![Circle](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/4pasted_image_20230718012451.png)
+![Circle](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/4pasted_image_20230718012451.png)
 
 At the top of your screen, you'll see an icon that looks like two overlapping rectangles; click that!
 
-![Boolean operators](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/5pasted_image_20230718012524.png)
+![Boolean operators](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/5pasted_image_20230718012524.png)
 
 These are Figma's boolean operators!! 😍😍
 
@@ -261,45 +261,45 @@ You have four options:
 > The **Subtract** boolean operator! We want to remove the smaller circle from the larger one.
 >
 > Awesome! Now we'll select both and perform that operation:
-> ![Subtract](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/6pasted_image_20230718112359.png)
+> ![Subtract](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/6pasted_image_20230718112359.png)
 
 It's starting to look more and more like a charm!
-![Charm](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/7pasted_image_20230718112519.png)
+![Charm](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/7pasted_image_20230718112519.png)
 
 Now, I'll add some decorations and drop shadow, and we'll have a completed element!
 
-![Charm with effects](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/8pasted_image_20230718112914.png)
+![Charm with effects](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/8pasted_image_20230718112914.png)
 
 If I have multiple layers that I want to fit into a circle, I can use Figma's **Mask** tool!
-![Mask select](https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/9pasted_image_20230718113841.png)
+![Mask select](https://cdn.hackclub.com/rescue?url=https://cloud-rh9f8bcjk-hack-club-bot.vercel.app/9pasted_image_20230718113841.png)
 _Here, I've created a new circle to use as the frame and selected all the layers I want to be inside of it!_
 
 This tool allows you to use a layer as a "cutout" for another, and we can even adjust it after masking!
 
 Here's the result:
-![Masked layers](https://cloud-f6y742j59-hack-club-bot.vercel.app/0pasted_image_20230718114047.png)
+![Masked layers](https://cdn.hackclub.com/rescue?url=https://cloud-f6y742j59-hack-club-bot.vercel.app/0pasted_image_20230718114047.png)
 
 Now, we'll place in a product image (ill use the mockup we designed earlier).
-![Background + Product](https://cloud-rgpmdor1b-hack-club-bot.vercel.app/1pasted_image_20230722221003.png)
+![Background + Product](https://cdn.hackclub.com/rescue?url=https://cloud-rgpmdor1b-hack-club-bot.vercel.app/1pasted_image_20230722221003.png)
 _To make the background stars, I created 4 stars and dropped the opacity to ~60%_
 
 From here, I can add some text using the **Text Tool (T)**, setting its fill color to whatever I want.
 
-![With Text](https://cloud-rgpmdor1b-hack-club-bot.vercel.app/2pasted_image_20230722221229.png)
+![With Text](https://cdn.hackclub.com/rescue?url=https://cloud-rgpmdor1b-hack-club-bot.vercel.app/2pasted_image_20230722221229.png)
 
 Awesome! I'll create a couple more to create a grid-like format.
 
-![Few more!](https://cloud-rgpmdor1b-hack-club-bot.vercel.app/3pasted_image_20230722221310.png)
+![Few more!](https://cdn.hackclub.com/rescue?url=https://cloud-rgpmdor1b-hack-club-bot.vercel.app/3pasted_image_20230722221310.png)
 
 As you might have guessed, the footer will also be the same; we'll use a rectangle as a background:
-![Step 1](https://cloud-rgpmdor1b-hack-club-bot.vercel.app/4pasted_image_20230722221404.png)
+![Step 1](https://cdn.hackclub.com/rescue?url=https://cloud-rgpmdor1b-hack-club-bot.vercel.app/4pasted_image_20230722221404.png)
 
 Add in star shapes with the **Star Tool** and add our logo!
-![Step 2](https://cloud-rgpmdor1b-hack-club-bot.vercel.app/5pasted_image_20230722221434.png)
+![Step 2](https://cdn.hackclub.com/rescue?url=https://cloud-rgpmdor1b-hack-club-bot.vercel.app/5pasted_image_20230722221434.png)
 
 After that, it's up to us to add whatever information we think is necessary. I'll add a privacy & terms page and a contact us page :D
 
-![Step 3](https://cloud-rgpmdor1b-hack-club-bot.vercel.app/6pasted_image_20230722221519.png)
+![Step 3](https://cdn.hackclub.com/rescue?url=https://cloud-rgpmdor1b-hack-club-bot.vercel.app/6pasted_image_20230722221519.png)
 
 Try creating the Navbar by yourself :)
 
@@ -330,29 +330,29 @@ These are layers that reference another layer instead of having its own value. I
 
 ### Layer
 
-![Layer Animation](https://cloud-faklou4uh-hack-club-bot.vercel.app/0color-scheme-_remix_.gif)
+![Layer Animation](https://cdn.hackclub.com/rescue?url=https://cloud-faklou4uh-hack-club-bot.vercel.app/0color-scheme-_remix_.gif)
 
 ### Asset
 
-![Asset Animation](https://cloud-ghmaoucif-hack-club-bot.vercel.app/0color-scheme-_remix___1_.gif)
+![Asset Animation](https://cdn.hackclub.com/rescue?url=https://cloud-ghmaoucif-hack-club-bot.vercel.app/0color-scheme-_remix___1_.gif)
 
 First, we'll create a new page so that we have our final prototype in one place. We can do this by expanding the "Page" icon on the left sidebar and clicking the '+' icon when it appears. Name this page **Assets**.
 
 Now, we'll copy over the elements that we want to turn into components.
 
-![Copied Elements](https://cloud-e1j5bcew3-hack-club-bot.vercel.app/0pasted_image_20230717003414.png)
+![Copied Elements](https://cdn.hackclub.com/rescue?url=https://cloud-e1j5bcew3-hack-club-bot.vercel.app/0pasted_image_20230717003414.png)
 
 Now, select the entire asset, right-click, and select "**Create Component**"
 
-![Create Component](https://cloud-e1j5bcew3-hack-club-bot.vercel.app/1pasted_image_20230717003457.png)
+![Create Component](https://cdn.hackclub.com/rescue?url=https://cloud-e1j5bcew3-hack-club-bot.vercel.app/1pasted_image_20230717003457.png)
 
 Do the same for every other asset you want to create. You'll know you've done it correctly if they appear purple in the left sidebar.
 
-![Component layers](https://cloud-e1j5bcew3-hack-club-bot.vercel.app/2pasted_image_20230717003601.png)
+![Component layers](https://cdn.hackclub.com/rescue?url=https://cloud-e1j5bcew3-hack-club-bot.vercel.app/2pasted_image_20230717003601.png)
 
 When you open the **Assets** tab in the left sidebar, you'll get the chance to drag it into your project!
 
-![Asset sidebar](https://cloud-e1j5bcew3-hack-club-bot.vercel.app/3pasted_image_20230717003648.png)
+![Asset sidebar](https://cdn.hackclub.com/rescue?url=https://cloud-e1j5bcew3-hack-club-bot.vercel.app/3pasted_image_20230717003648.png)
 
 You did it hacker!
 
@@ -366,19 +366,19 @@ You might have noticed a **Prototype** tab in the right sidebar; this tab helps 
 
 For example, if we click an element on our **About** page, we'll get options to create an interaction.
 
-![Prototype tab](https://cloud-e1j5bcew3-hack-club-bot.vercel.app/4pasted_image_20230717004550.png)
+![Prototype tab](https://cdn.hackclub.com/rescue?url=https://cloud-e1j5bcew3-hack-club-bot.vercel.app/4pasted_image_20230717004550.png)
 
 Let's try that!
-![Interaction](https://cloud-e1j5bcew3-hack-club-bot.vercel.app/5pasted_image_20230717004607.png)
+![Interaction](https://cdn.hackclub.com/rescue?url=https://cloud-e1j5bcew3-hack-club-bot.vercel.app/5pasted_image_20230717004607.png)
 
 For now, we'll just use the **On Click** trigger with the **Navigate to** response. This gives us a list of frames in our project we can jump to:
-![Navigate to?](https://cloud-e1j5bcew3-hack-club-bot.vercel.app/6pasted_image_20230717004656.png)
+![Navigate to?](https://cdn.hackclub.com/rescue?url=https://cloud-e1j5bcew3-hack-club-bot.vercel.app/6pasted_image_20230717004656.png)
 
 Select the one you want and customize the transition!
 p.s. for similar pages (such as your product page), it might be more intuitive for a "**Smart Animate**" transition.
 
 For example, I set the transition between the home and about page to "**Smart Animate**", and this is the result:
-![Animation Preview](https://cloud-h7lkfzs4c-hack-club-bot.vercel.app/02023-07-18_11-49-28.gif)
+![Animation Preview](https://cdn.hackclub.com/rescue?url=https://cloud-h7lkfzs4c-hack-club-bot.vercel.app/02023-07-18_11-49-28.gif)
 
 **Follow the same technique for every single clickable element!**
 
@@ -387,7 +387,7 @@ For example, I set the transition between the home and about page to "**Smart An
 Once you're finished, click the present icon on the top right corner (looks like a play button) and enjoy the show! Make sure you're on the final prototype page and not the assets page!
 
 Splendid! Here are my interactions in my example design:
-![Final prototype](https://cloud-e1j5bcew3-hack-club-bot.vercel.app/7pasted_image_20230717005112.png)
+![Final prototype](https://cdn.hackclub.com/rescue?url=https://cloud-e1j5bcew3-hack-club-bot.vercel.app/7pasted_image_20230717005112.png)
 
 Hopefully, your design looks totally unique and different!
 
@@ -396,7 +396,7 @@ Get ready to pitch it to the hosts... 🍿
 ## Up for a challenge?
 
 There's a really awesome tool in your toolbar that I haven't mentioned.
-![Plugins?!](https://cloud-e1j5bcew3-hack-club-bot.vercel.app/8pasted_image_20230717005231.png)
+![Plugins?!](https://cdn.hackclub.com/rescue?url=https://cloud-e1j5bcew3-hack-club-bot.vercel.app/8pasted_image_20230717005231.png)
 
 The **Plugins** tab :00
 
@@ -410,7 +410,7 @@ Feel free to browse through and find something awesome for your design. One that
 If you'd like to implement this prototype into a working website, check out the jam "**Wielding the Elemental Magic of the Web (not evil)**" to figure out how to implement your design in HTML and CSS! Also, try enabling "**Dev Mode**" in Figma (a switch on the top right corner) to see property values in CSS and example code for some objects!
 
 It's been a blast jamming out with you! Catch you later :>
-<video controls style={{width: "400px"}}> <source src="https://cloud-f39p2nwab-hack-club-bot.vercel.app/00718.mp4" type="video/mp4"/> </video>
+<video controls style={{width: "400px"}}> <source src="https://cdn.hackclub.com/rescue?url=https://cloud-f39p2nwab-hack-club-bot.vercel.app/00718.mp4" type="video/mp4"/> </video>
 <br/>
 <small>"Oh, Christmas Tree" Kevin MacLeod (incompetech.com)
 Licensed under Creative Commons: By Attribution 4.0 License

--- a/jams/singles/particle-physics/en-US.md
+++ b/jams/singles/particle-physics/en-US.md
@@ -3,7 +3,7 @@ title: 'Making a Basic Particle Physics Simulation'
 description: Creating a basic particle physics simulation and rendering using p5.js
 contributor: 'sahitid'
 originalAuthor: 'SquarePear'
-thumbnail: 'https://cloud-k50jkthdw.vercel.app/0particle-physics-summary.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-k50jkthdw.vercel.app/0particle-physics-summary.png'
 timeEstimate: '30-45 Min'
 difficulty: 'Beginner'
 keywords: 'Beta, motion, fractal, particle, physics, particle physics'

--- a/jams/singles/sound-galaxy/en-US.md
+++ b/jams/singles/sound-galaxy/en-US.md
@@ -3,7 +3,7 @@ title: 'Create Your Own Space-Themed Audio Visualizer'
 description: Visualize sound by making particles move in a galaxy!
 contributor: 'sahitid'
 originalAuthor: 'MatthewStanciu'
-thumbnail: 'https://cloud-mtoslrg9r-hack-club-bot.vercel.app/2final-demo.gif'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-mtoslrg9r-hack-club-bot.vercel.app/2final-demo.gif'
 timeEstimate: '30-45 Min'
 difficulty: 'Beginner'
 keywords: 'Beta, sound, sound galaxy, beginner, web dev, p5.js, '

--- a/jams/singles/speak-colors/en-US.md
+++ b/jams/singles/speak-colors/en-US.md
@@ -3,7 +3,7 @@ title: 'Speak & Color Your Screen Outloud'
 description: Color your screen with your voice via speech recognition.
 contributor: 'sahitid'
 originalAuthor: 'lachlanjc'
-thumbnail: 'https://cloud-3ipvngxk0-hack-club-bot.vercel.app/0screen_shot_2022-01-24_at_1.04.09_pm.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-3ipvngxk0-hack-club-bot.vercel.app/0screen_shot_2022-01-24_at_1.04.09_pm.png'
 timeEstimate: '30-45 Min'
 difficulty: 'Beginner'
 keywords: 'Beta, speech recognition, colors, speak colors'

--- a/jams/singles/splatter paint/en-US.md
+++ b/jams/singles/splatter paint/en-US.md
@@ -4,7 +4,7 @@ description: >
   Crazy colorful splatter paint in your browser with Paper.js
 contributor: 'sahitid'
 originalAuthor: 'MatthewStanciu'
-thumbnail: 'https://cloud-3aosybiuc-hack-club-bot.vercel.app/1final-demo.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-3aosybiuc-hack-club-bot.vercel.app/1final-demo.png'
 timeEstimate: '30-45 Min'
 difficulty: 'Beginner'
 keywords: 'Beta, colors, paint, art, splatter paint'
@@ -22,7 +22,7 @@ One of the most common myths about coding among people who are first learning to
 
 You’re going to crush this myth in this workshop by making crazy, colorful splatter paint right in your web browser, in only 20 minutes.
 
-![Colorful patterns of dots and lines on a canvas](https://cloud-3aosybiuc-hack-club-bot.vercel.app/1final-demo.png)
+![Colorful patterns of dots and lines on a canvas](https://cdn.hackclub.com/rescue?url=https://cloud-3aosybiuc-hack-club-bot.vercel.app/1final-demo.png)
 
 [Final code](https://repl.it/@TechBug2012/splatter-paint#index.html)
 [Final demo](https://splatter-paint.techbug2012.repl.co)
@@ -114,7 +114,7 @@ function onMouseMove(event) {
 
 Instead of using the more common hexademical or RGB color systems, Paper.js uses the HSB color system, which uses angles on a color wheel to describe color. In the HSB color system, 0 = 0° = red, and `360*n`° is also red.
 
-![Color wheel in which each color is assigned a degree value](https://cloud-b0scmt0cu-hack-club-bot.vercel.app/0hsb-color-wheel.png)
+![Color wheel in which each color is assigned a degree value](https://cdn.hackclub.com/rescue?url=https://cloud-b0scmt0cu-hack-club-bot.vercel.app/0hsb-color-wheel.png)
 
 (If you’re interested in learning more about the HSB color system, check out [this fantastic explanation](https://learnui.design/blog/the-hsb-color-system-practicioners-primer.html))
 
@@ -163,23 +163,23 @@ canvas {
 
 If you run your repl again, you should notice that your red circles are now filling the entire screen!
 
-![Random pattern formed by red circles](https://cloud-3aosybiuc-hack-club-bot.vercel.app/6red-circles.jpg)
+![Random pattern formed by red circles](https://cdn.hackclub.com/rescue?url=https://cloud-3aosybiuc-hack-club-bot.vercel.app/6red-circles.jpg)
 
 ## Making it Splattery
 
 We’re getting somewhere, but this still doesn’t feel very splattery.
 
-![colorful paint randomly splattered on a canvas](https://cloud-3aosybiuc-hack-club-bot.vercel.app/5real-splatter-paint.jpg)
+![colorful paint randomly splattered on a canvas](https://cdn.hackclub.com/rescue?url=https://cloud-3aosybiuc-hack-club-bot.vercel.app/5real-splatter-paint.jpg)
 
 Part of what makes splatter paint so fun to create and look at is the chaotic randomness of everything on the canvas. So, if you want to get your website as close to splatter paint as possible, the best way to do it is to introduce some randomness.
 
 Change the radius of your circles from `10` to `Math.round(Math.random() * 25) + 5`. This makes the radius a random number between 5 and 30. Then run the repl again.
 
-![Circles with large radii forming a random pattern on a canvas](https://cloud-3aosybiuc-hack-club-bot.vercel.app/4random-radius.jpg)
+![Circles with large radii forming a random pattern on a canvas](https://cdn.hackclub.com/rescue?url=https://cloud-3aosybiuc-hack-club-bot.vercel.app/4random-radius.jpg)
 
 Not bad, but it feels sort of mashed together, doesn’t it? Maybe we can make each circle unique by making it a different color than the last. Try changing the hue from `0` to `event.count * 3`. Run the repl and see what happens.
 
-![Rainbow assortment of circles of various sizes on a canvas](https://cloud-3aosybiuc-hack-club-bot.vercel.app/3rainbow-colors.jpg)
+![Rainbow assortment of circles of various sizes on a canvas](https://cdn.hackclub.com/rescue?url=https://cloud-3aosybiuc-hack-club-bot.vercel.app/3rainbow-colors.jpg)
 
 `event.count * 3` creates a rainbow effect by setting the hue on each circle to the total number of times a circle has been drawn multiplied by 3, which jumps around the HSB color wheel. And it looks great!
 

--- a/jams/singles/story-game/Level-1.md
+++ b/jams/singles/story-game/Level-1.md
@@ -8,7 +8,7 @@ Here is the example code of what we're going to create!: https://replit.com/@Con
 
 Building a Choose Your Own Adventure Game is kinda like making a **pizza**! First, the base! The most important part, and the thing that holds everything up... *drum roll please...* the story line!
 
-![The storyline, the base of all games, is like the dough of a pizza. ](https://cloud-kck0n0txs-hack-club-bot.vercel.app/0copy_of_copy_of_arial.gif)
+![The storyline, the base of all games, is like the dough of a pizza. ](https://cdn.hackclub.com/rescue?url=https://cloud-kck0n0txs-hack-club-bot.vercel.app/0copy_of_copy_of_arial.gif)
 
 ## What Makes Text Based Adventure Games SO Playable?
 
@@ -23,7 +23,7 @@ So what's the most important part? Planning.
 
 ## Game Design
 
-![You need to branch out with Gane Design](https://cloud-d4qej17bj-hack-club-bot.vercel.app/0story2.gif)
+![You need to branch out with Gane Design](https://cdn.hackclub.com/rescue?url=https://cloud-d4qej17bj-hack-club-bot.vercel.app/0story2.gif)
 
 ### Choosing a Theme or Setting! 
 
@@ -45,7 +45,7 @@ The best part is the sky's the limit! Keep brainstorming until you find somethin
 Also consider the potential story choices, depth, and player engagement.
 
 ### Planning Game Structure!
-![Planning a player's journey](https://cloud-ojeynixq6-hack-club-bot.vercel.app/0untitled_design-removebg-preview.png)
+![Planning a player's journey](https://cdn.hackclub.com/rescue?url=https://cloud-ojeynixq6-hack-club-bot.vercel.app/0untitled_design-removebg-preview.png)
 
 Define what the game structure by figuring out the overall goal that players will strive to achieve. It can be finding treasure, surviving on an abandoned island, solving a mystery, or saving the world!
 
@@ -54,7 +54,7 @@ In this stage determine the key challenges, events, or puzzles the players will 
 Now figure out your player's choices. Imagine a tree, and each choice is a different branch of the story. Identify these "branching off" points in the narrative where the player's choices will affect the outcome. 
 
 ### Characters!
-![Characters](https://cloud-8yiaur9jb-hack-club-bot.vercel.app/0untitled_design__2_.gif)
+![Characters](https://cdn.hackclub.com/rescue?url=https://cloud-8yiaur9jb-hack-club-bot.vercel.app/0untitled_design__2_.gif)
 
 This is also a good time to figure out any potential non-player characters (NPC's). These are characters that the player can interact with and can make the storyline richer.  
 
@@ -72,11 +72,11 @@ Once you're all done writing everything up- let's start programming!
 
 
 ## Setting Up Replit
-![Replit.com Home Page](https://cloud-rmnz8besq-hack-club-bot.vercel.app/0replit_sigh_up.gif) 
+![Replit.com Home Page](https://cdn.hackclub.com/rescue?url=https://cloud-rmnz8besq-hack-club-bot.vercel.app/0replit_sigh_up.gif) 
 
 Before continuing further, make sure to set up or log in to your https://replit.com account. 
 
-![Create a New Repl](https://cloud-lthzt6trl-hack-club-bot.vercel.app/0untitled_design.gif)
+![Create a New Repl](https://cdn.hackclub.com/rescue?url=https://cloud-lthzt6trl-hack-club-bot.vercel.app/0untitled_design.gif)
 
 Once there click on 'Create a New Repl'
 

--- a/jams/singles/story-game/Level-2.md
+++ b/jams/singles/story-game/Level-2.md
@@ -2,7 +2,7 @@
 ##  Level 2: Sonic Sagas
 ### Adding Music and Style to your Text-Based Adventure Game
 
-![Adding music and style](https://cloud-3usasijgs-hack-club-bot.vercel.app/0copy_of_arial.gif)
+![Adding music and style](https://cdn.hackclub.com/rescue?url=https://cloud-3usasijgs-hack-club-bot.vercel.app/0copy_of_arial.gif)
 
 Once again, great job in finishing ***Level 1: The Storyteller's Forge***. Now we're moving on to the second layer of the **pizza**, the *sauce*! A cool add on that gives a kick of flavor! In this level we will be learning how to add background music, sound effects, text animation, and color! 
 

--- a/jams/singles/story-game/Level-3.md
+++ b/jams/singles/story-game/Level-3.md
@@ -3,7 +3,7 @@
 
 ### Creating a Graphical User Interface 
 
-![Putting everything together](https://cloud-8dmeqbifb-hack-club-bot.vercel.app/0arial.gif)
+![Putting everything together](https://cdn.hackclub.com/rescue?url=https://cloud-8dmeqbifb-hack-club-bot.vercel.app/0arial.gif)
 
 Once again, great job in finishing **_Level 2: Sonic Sagas_**. Now we're moving on to the third and **final** layer of the **pizza**, the *cheese*! It's the thing that all of our users will get to see and experience first before the storyline, music, etc. ***THE GUI!*** 
 
@@ -254,7 +254,7 @@ Keep storing each part of your in `def` functions... after you're done, let's ge
 
 We've been talking a lot about windows and frames-- but what are they and what's the difference? Lastly, *how* do we *MAKE* them?
 
-![Comparing windows and frames](https://cloud-p55izwnla-hack-club-bot.vercel.app/0digital.png)
+![Comparing windows and frames](https://cdn.hackclub.com/rescue?url=https://cloud-p55izwnla-hack-club-bot.vercel.app/0digital.png)
 
 This might sound crazy but imagine a house. The window is like an entire house. It has it's own structure, windows and doors (title bar, and controls), walls (size of window), etc. and it is the main thing that the user interacts with. 
 

--- a/jams/singles/story-game/en-US.md
+++ b/jams/singles/story-game/en-US.md
@@ -6,7 +6,7 @@ description: >
     features! The most important part is to use your imagination since there is no limit to what YOU can create!
 contributor: 'necode2'
 contributorSlackID: 'U05E5U2D91P'
-thumbnail: 'https://cloud-c7go8kd3a-hack-club-bot.vercel.app/0ezgif-4-92cc368f0d.gif'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-c7go8kd3a-hack-club-bot.vercel.app/0ezgif-4-92cc368f0d.gif'
 timeEstimate: '30 Min'
 difficulty: 'Beginner'
 keywords: 'Game, Adventure, Pythons, CYOA, replit, storytelling, interactive'
@@ -15,10 +15,10 @@ presentation: 'https://www.figma.com/file/GzkGDAybZ9hO1AHfWMMvAR/CYOA-New-Jam-Pr
 id=0%3A1&mode=design&t=u1D1Lu50ZkHThvo1-1'  
 presentationPlay: 'https://www.figma.com/proto/GzkGDAybZ9hO1AHfWMMvAR/CYOA-New-Jam-Presentation?type=design&node-id=5-
 2343&t=tg1xDh0nrZuq8lMk-1&scaling=min-zoom&page-id=0%3A1&mode=design'  
-presentationPDF: 'https://cloud-b7pr0h6i7-hack-club-bot.vercel.app/0cyoa_new_jam_presentation.pdf'  
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-b7pr0h6i7-hack-club-bot.vercel.app/0cyoa_new_jam_presentation.pdf'  
 notes: ''  
-poster: 'https://cloud-fulkcjrnl-hack-club-bot.vercel.app/0build_a_choose_your_own_adventure_game_.pdf'  
-video: 'https://cloud-9mn1z1s9z-hack-club-bot.vercel.app/0coose_your_own_adventure_game.mp4'  
+poster: 'https://cdn.hackclub.com/rescue?url=https://cloud-fulkcjrnl-hack-club-bot.vercel.app/0build_a_choose_your_own_adventure_game_.pdf'  
+video: 'https://cdn.hackclub.com/rescue?url=https://cloud-9mn1z1s9z-hack-club-bot.vercel.app/0coose_your_own_adventure_game.mp4'  
 slug: 'story-game' 
 ---
 ## Choose Wisely, Code Boldly; Crafting a Build Your Own Adventure Game!
@@ -55,7 +55,7 @@ Here is Replit's Documentation for future Reference: https://docs.replit.com/
 ## Level 1: The Storyteller's Forge
 ### Create your Text-Based Adventure Game
 
-<video src="https://cloud-mxm9fsiqn-hack-club-bot.vercel.app/0level_2_cyoa.mp4" controls="controls" style={{width: "100%"}}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-mxm9fsiqn-hack-club-bot.vercel.app/0level_2_cyoa.mp4" controls="controls" style={{width: "100%"}}></video>
 
 
 Here is the example code of what we're going to create!: https://replit.com/@ConnemaraPony/Beginner-CYOA?v=1
@@ -63,7 +63,7 @@ Here is the example code of what we're going to create!: https://replit.com/@Con
 Building a Choose Your Own Adventure Game is kinda like making a **pizza**! First, the base! The most important part, and the thing that 
 holds everything up... *drum roll please...* the storyline!
 
-![The storyline, the base of all games, is like the dough of a pizza. ](https://cloud-kck0n0txs-hack-club-bot.vercel.app/0copy_of_copy_of_arial.gif)
+![The storyline, the base of all games, is like the dough of a pizza. ](https://cdn.hackclub.com/rescue?url=https://cloud-kck0n0txs-hack-club-bot.vercel.app/0copy_of_copy_of_arial.gif)
 
 ## What Makes Text Based Adventure Games SO Playable?
 
@@ -81,7 +81,7 @@ So what's the most important part? Planning.
 
 ## Game Design
 
-![You need to branch out with Gane Design](https://cloud-d4qej17bj-hack-club-bot.vercel.app/0story2.gif)
+![You need to branch out with Gane Design](https://cdn.hackclub.com/rescue?url=https://cloud-d4qej17bj-hack-club-bot.vercel.app/0story2.gif)
 
 ### Choosing a Theme or Setting! 
 
@@ -104,7 +104,7 @@ The best part is the sky's the limit! Keep brainstorming until you find somethin
 Also consider the potential story choices, depth, and player engagement.
 
 ### Planning Game Structure!
-![Planning a player's journey](https://cloud-ojeynixq6-hack-club-bot.vercel.app/0untitled_design-removebg-preview.png)
+![Planning a player's journey](https://cdn.hackclub.com/rescue?url=https://cloud-ojeynixq6-hack-club-bot.vercel.app/0untitled_design-removebg-preview.png)
 
 Define what the game structure by figuring out the overall goal that players will strive to achieve. It can be finding treasure, surviving 
 on an abandoned island, solving a mystery, or saving the world!
@@ -116,7 +116,7 @@ Now figure out your player's choices. Imagine a tree, and each choice is a diffe
 points in the narrative where the player's choices will affect the outcome. 
 
 ### Characters!
-![Characters](https://cloud-8yiaur9jb-hack-club-bot.vercel.app/0untitled_design__2_.gif)
+![Characters](https://cdn.hackclub.com/rescue?url=https://cloud-8yiaur9jb-hack-club-bot.vercel.app/0untitled_design__2_.gif)
 
 This is also a good time to figure out any potential non-player characters (NPC's). These are characters that the player can interact with 
 and can make the storyline richer.  
@@ -138,11 +138,11 @@ Once you're all done writing everything up- let's start programming!
 
 
 ## Setting Up Replit
-![Replit.com Home Page](https://cloud-rmnz8besq-hack-club-bot.vercel.app/0replit_sigh_up.gif) 
+![Replit.com Home Page](https://cdn.hackclub.com/rescue?url=https://cloud-rmnz8besq-hack-club-bot.vercel.app/0replit_sigh_up.gif) 
 
 Before continuing further, make sure to set up or log in to your https://replit.com account. 
 
-![Create a New Repl](https://cloud-lthzt6trl-hack-club-bot.vercel.app/0untitled_design.gif)
+![Create a New Repl](https://cdn.hackclub.com/rescue?url=https://cloud-lthzt6trl-hack-club-bot.vercel.app/0untitled_design.gif)
 
 Once there click on 'Create a New Repl'
 
@@ -325,13 +325,13 @@ Go to the next level now!
 ##  Level 2: Sonic Sagas
 ### Adding Music and Style to your Text-Based Adventure Game
 
-![Adding music and style](https://cloud-3usasijgs-hack-club-bot.vercel.app/0copy_of_arial.gif)
+![Adding music and style](https://cdn.hackclub.com/rescue?url=https://cloud-3usasijgs-hack-club-bot.vercel.app/0copy_of_arial.gif)
 
 Once again, great job in finishing ***Level 1: The Storyteller's Forge***. Now we're moving on to the second layer of the **pizza**, the 
 *sauce*! A cool add-on that gives a kick of flavor! In this level, we will be learning how to add background music, sound effects, text 
 animation, and color! 
 
-<video src="https://cloud-mxm9fsiqn-hack-club-bot.vercel.app/0level_2_cyoa.mp4" controls="controls" style={{width: "100%"}}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-mxm9fsiqn-hack-club-bot.vercel.app/0level_2_cyoa.mp4" controls="controls" style={{width: "100%"}}></video>
 
 Here is the example code of what we're going to create!: https://replit.com/@ConnemaraPony/Intermediate-CYOA?v=1
 
@@ -555,12 +555,12 @@ Go to the next level now!
 
 ### Creating a Graphical User Interface 
 
-![Putting everything together](https://cloud-8dmeqbifb-hack-club-bot.vercel.app/0arial.gif)
+![Putting everything together](https://cdn.hackclub.com/rescue?url=https://cloud-8dmeqbifb-hack-club-bot.vercel.app/0arial.gif)
 
 Once again, great job in finishing **_Level 2: Sonic Sagas_**. Now we're moving on to the third and **final** layer of the **pizza**, 
 the *cheese*! It's the thing that all of our users will get to see and experience first before the storyline, music, etc. ***THE GUI!*** 
 
-<video src="https://cloud-o4r2cm0xj-hack-club-bot.vercel.app/0point_systems_were_created_at_the_end_of_the_level_1_jam_.mp4" controls="controls" style={{width: "100%"}}></video>
+<video src="https://cdn.hackclub.com/rescue?url=https://cloud-o4r2cm0xj-hack-club-bot.vercel.app/0point_systems_were_created_at_the_end_of_the_level_1_jam_.mp4" controls="controls" style={{width: "100%"}}></video>
 
 Here is the example code of what we're going to create!: https://replit.com/@ConnemaraPony/Advanced-CYOA?v=1
 
@@ -816,7 +816,7 @@ Keep storing each part of your in `def` functions... after you're done, let's ge
 
 We've been talking a lot about windows and frames-- but what are they and what's the difference? Lastly, *how* do we *MAKE* them?
 
-![Comparing windows and frames](https://cloud-p55izwnla-hack-club-bot.vercel.app/0digital.png)
+![Comparing windows and frames](https://cdn.hackclub.com/rescue?url=https://cloud-p55izwnla-hack-club-bot.vercel.app/0digital.png)
 
 This might sound crazy but imagine a house. The window is like an entire house. It has its own structure, windows and doors (title bar, 
 and controls), walls (size of window), etc. and it is the main thing that the user interacts with. 

--- a/jams/singles/voxel-animation/en-US.md
+++ b/jams/singles/voxel-animation/en-US.md
@@ -4,15 +4,15 @@ description: >
     In this Jam, you'll be creating an awesome unique Lofi Animation using Voxels! It will be a lot of fun and you will have an awesome animation as a result!
 contributor: "GalaxyGamingBoy"
 contributorSlackID: "U04FMKCVASJ"
-thumbnail: "https://cloud-mzd35dnd5-hack-club-bot.vercel.app/0lofi.gif"
+thumbnail: "https://cdn.hackclub.com/rescue?url=https://cloud-mzd35dnd5-hack-club-bot.vercel.app/0lofi.gif"
 timeEstimate: "60 Min"
 difficulty: "Intermediate"
 keywords: "Web, HTML, javascript, replit, Web, Voxel, Cube, Textures, Animation, 3d"
 language: "Javascript"
 presentation: "https://www.figma.com/file/ImHTihOiCSxpcpS2AC7zYy/Voxel-Animation---Slides"
 presentationPlay: "https://www.figma.com/proto/ImHTihOiCSxpcpS2AC7zYy/Voxel-Animation---Slides"
-presentationPDF: "https://cloud-abxtk9jcc-hack-club-bot.vercel.app/0voxel_animation_-_slides__1_.pdf"
-notes: "https://cloud-irkqrfqvg-hack-club-bot.vercel.app/0three.js_ultimate_geometry_guide__1_.pdf"
+presentationPDF: "https://cdn.hackclub.com/rescue?url=https://cloud-abxtk9jcc-hack-club-bot.vercel.app/0voxel_animation_-_slides__1_.pdf"
+notes: "https://cdn.hackclub.com/rescue?url=https://cloud-irkqrfqvg-hack-club-bot.vercel.app/0three.js_ultimate_geometry_guide__1_.pdf"
 poster: ""
 video: ""
 slug: "voxel-animation"
@@ -20,7 +20,7 @@ slug: "voxel-animation"
 
 
 ~60+ Minutes, Basic javascript and html knowledge needed
-![demo_dot_webm](https://cloud-1duz1dnxo-hack-club-bot.vercel.app/0demo.gif)
+![demo_dot_webm](https://cdn.hackclub.com/rescue?url=https://cloud-1duz1dnxo-hack-club-bot.vercel.app/0demo.gif)
 
 ( _This is a demo animation, this jam encourages to create your **own!**_ )
 
@@ -60,20 +60,20 @@ You will fork the [template from this link](https://replit.com/@GalaxyGamingBoy/
 After visiting the link on the right hand side of the screen there is a `FORK` button. Click it!
 After clicking enter your voxel animation name and click `FORK REPL`.
 
-![Fork button](https://cloud-c7utcgww6-hack-club-bot.vercel.app/0image.png)
-![Fork Modal](https://cloud-puqb2ludk-hack-club-bot.vercel.app/0image.png)
+![Fork button](https://cdn.hackclub.com/rescue?url=https://cloud-c7utcgww6-hack-club-bot.vercel.app/0image.png)
+![Fork Modal](https://cdn.hackclub.com/rescue?url=https://cloud-puqb2ludk-hack-club-bot.vercel.app/0image.png)
 
 Here is a quick GIF of the proccess, if you want to verify! :D
-![replit-fork-dot-gif](https://cloud-hz6v4e4i3-hack-club-bot.vercel.app/0replit-fork-dot-gif.gif)
+![replit-fork-dot-gif](https://cdn.hackclub.com/rescue?url=https://cloud-hz6v4e4i3-hack-club-bot.vercel.app/0replit-fork-dot-gif.gif)
 
 Well now congratulations! You are a **master** of forking projects, here is a celebratory meme for you!
-<img src="https://cloud-lnspzc1vi-hack-club-bot.vercel.app/0meme_fork.jpg" width="35%"/>
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-lnspzc1vi-hack-club-bot.vercel.app/0meme_fork.jpg" width="35%"/>
 
 ### Explaining Replit
 
 After that your project that the animation will live in should be loaded into the same tab.
 It should look like this:
-![Replit](https://cloud-2ubu2qozr-hack-club-bot.vercel.app/0image.png)
+![Replit](https://cdn.hackclub.com/rescue?url=https://cloud-2ubu2qozr-hack-club-bot.vercel.app/0image.png)
 Bare with me for a bit while I explain the basics for replit, here are the breakdown of the steps shown above:
 
 1. Indicates the file manager, there you can see all of your files.
@@ -85,7 +85,7 @@ Bare with me for a bit while I explain the basics for replit, here are the break
 	Replit is a web-based independent development environment (IDE). Basically Replit allows you to write code in your browser and instantly deploy it!
 	
 	<div>
-		<img src="https://cloud-lnspzc1vi-hack-club-bot.vercel.app/1meme_magic.jpg" width="40%"/>
+		<img src="https://cdn.hackclub.com/rescue?url=https://cloud-lnspzc1vi-hack-club-bot.vercel.app/1meme_magic.jpg" width="40%"/>
 	</div>
 </Dropdown>
 
@@ -100,7 +100,7 @@ The process of uploading assets like images is very easy!
 All you need to do is to drag and drop it into the `assets` folder ot wherever else in your project!
 
 <video controls style={{width: "400px"}}>
-	<source src="https://cloud-ldawt72v9-hack-club-bot.vercel.app/0uploadtoreplit.mp4" type="video/mp4"/>
+	<source src="https://cdn.hackclub.com/rescue?url=https://cloud-ldawt72v9-hack-club-bot.vercel.app/0uploadtoreplit.mp4" type="video/mp4"/>
 </video>
 
 So yea, that's everything about replit, that you will need to know!
@@ -220,7 +220,7 @@ stopRec.addEventListener("click", () => {
 
 And the event listeners when clicked.
 
-![worker-gif-dot-gif](https://cloud-rln8wm7fd-hack-club-bot.vercel.app/0worker-phew-dot-gif.gif)
+![worker-gif-dot-gif](https://cdn.hackclub.com/rescue?url=https://cloud-rln8wm7fd-hack-club-bot.vercel.app/0worker-phew-dot-gif.gif)
 Phew that was a **lot**! But we can move over to the next session.
 The code snippets are already implemented so no need to worry about that!
 This section is purely informative.
@@ -235,7 +235,7 @@ This section will cover the basics of three.js, so you can start with the render
 
 Yes, it's time! This is where we import THREE.JS for rendering. :D
 If you had previous experience with Javascript you may already know how to import things but for those who don't, here is an explanatory Image.
-![image](https://cloud-oe00kf8q6-hack-club-bot.vercel.app/0image.png)
+![image](https://cdn.hackclub.com/rescue?url=https://cloud-oe00kf8q6-hack-club-bot.vercel.app/0image.png)
 For those who have figured it out by the image congrats!
 Imports are just requests to another javascript file saying that we want to load something from them.
 
@@ -267,14 +267,14 @@ document.body.appendChild(renderer.domElement);
 In the first line we initialize the THREE WebGL renderer, it will handle the rendering job.
 In the second line we set the rendering size, and we pass the window width and height.
 In the third line we append the renderer, so we can actually see.
-<img src="https://cloud-lnspzc1vi-hack-club-bot.vercel.app/1meme_magic.jpg" width="40%"/>
+<img src="https://cdn.hackclub.com/rescue?url=https://cloud-lnspzc1vi-hack-club-bot.vercel.app/1meme_magic.jpg" width="40%"/>
 
 ### The coordinate system
 
 Well let's make a quick reference to the **three.js coordinate system**.
 Like mostly all 3D applications, three.js utilizes the **Cartesian _coordinate system_**.
 Here is a quick illustration of it:
-![cartesian_system_illustration](https://cloud-brf44h742-hack-club-bot.vercel.app/0image.png)
+![cartesian_system_illustration](https://cdn.hackclub.com/rescue?url=https://cloud-brf44h742-hack-club-bot.vercel.app/0image.png)
 As shown above the height uses the **_Y_** variable, the depth uses the **_Z_**, and the width uses the **_X_** variable.
 Well that is all you need to know about it! Let's render some cubes! :D
 
@@ -465,7 +465,7 @@ Now
 </Dropdown>
 
 Well it is task time everyone!
-![time_meme-dot-jpg](https://cloud-qmjjp049v-hack-club-bot.vercel.app/0meme_time.jpg)
+![time_meme-dot-jpg](https://cdn.hackclub.com/rescue?url=https://cloud-qmjjp049v-hack-club-bot.vercel.app/0meme_time.jpg)
 
 <Dropdown title="Task">
 	Add 2 of your own cubes into the scene!
@@ -639,7 +639,7 @@ TIPS
 6) Feel free to seek the demo code for more examples
 ```
 
-If you would like to learn how to add more shapes to use in your lofi animation, check out the jam's note, printed or digitally. They can also be found [here](https://cloud-bt4376wp7-hack-club-bot.vercel.app/0three.js_ultimate_geometry_guide.pdf)
+If you would like to learn how to add more shapes to use in your lofi animation, check out the jam's note, printed or digitally. They can also be found [here](https://cdn.hackclub.com/rescue?url=https://cloud-bt4376wp7-hack-club-bot.vercel.app/0three.js_ultimate_geometry_guide.pdf)
 
 Farewell traveler!
 <img src="https://media1.giphy.com/media/6VriQO3GFRwwBVPbi4/giphy.gif?cid=ecf05e474dx0omnat02vthuv0n1komd3yefmcqhqljwguudnandep=v1_gifs_searchandrid=giphy.gif" width="25%"/>
@@ -661,7 +661,7 @@ It looks like you wanted to learn more, let's start with 3D models.
 
 I suggest using [this]([Goxel 0.10.5](https://goxel.xyz/live/)) tool for creating a 3D voxel model, because it is easy to use and it is **online**.
 After creating a model follow this guide:
-![export](https://cloud-de7xkh2bp-hack-club-bot.vercel.app/0image.png)
+![export](https://cdn.hackclub.com/rescue?url=https://cloud-de7xkh2bp-hack-club-bot.vercel.app/0image.png)
 Instructions as show above:
 
 1. Click the image button, it is known as **export**

--- a/jams/singles/web-ai-comic/en-US.md
+++ b/jams/singles/web-ai-comic/en-US.md
@@ -4,16 +4,16 @@ description: >
     In this jam, we'll be using ChatGPT to generate the text of a children's comic, and use Stable Diffusion to create pictures for the comic. Both ChatGPT and Stable Diffusion are completely free. Lastly, we'll walk through deploying your comic as a website (yes, with a live URL :)) so you can share it with your friends 🌎
 contributor: 'ganning127'
 contributorSlackID: 'U03336QJ21H'
-thumbnail: 'https://cloud-9f9dwksme-hack-club-bot.vercel.app/00000thumbnail__2___1_-2_70_50.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-9f9dwksme-hack-club-bot.vercel.app/00000thumbnail__2___1_-2_70_50.webp'
 timeEstimate: '60 Min'
 difficulty: 'Easy'
 keywords: 'AI, ChatGPT, Stable Diffusion, HTML, CSS, Machine Learning, Artificial Intelligence, AI, ML, chatgpt, openai, ai, ai api'
 language: 'ChatGPT,HTMl,CSS,StableDiffusion'
 presentation: 'https://www.figma.com/file/vPvkTekK6hzED7fowx0aBf/ComicBookAi?type=design&node-id=11%3A182&mode=design&t=Qgq1JvXvHyxwNwAo-1'
 presentationPlay: 'https://www.figma.com/proto/vPvkTekK6hzED7fowx0aBf/ComicBookAi?type=design&node-id=1-2&t=Qgq1JvXvHyxwNwAo-0&scaling=contain&page-id=0%3A1'
-presentationPDF: 'https://cloud-c4phbrzty-hack-club-bot.vercel.app/0comicbookai.pdf'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-c4phbrzty-hack-club-bot.vercel.app/0comicbookai.pdf'
 notes: 'https://hackmd.io/l3VKBJluTM2tdP40TDFCIw'
-poster: 'https://cloud-h5osxqcta-hack-club-bot.vercel.app/0build_your_own_comic_book_with_ai.pdf'
+poster: 'https://cdn.hackclub.com/rescue?url=https://cloud-h5osxqcta-hack-club-bot.vercel.app/0build_your_own_comic_book_with_ai.pdf'
 video: ''
 slug: 'web-ai-comic'
 ---
@@ -23,14 +23,14 @@ slug: 'web-ai-comic'
 Hey hacker, welcome to the land of writing and drawing, or rather, using **AI to write and draw for you**! 👋 In this jam, we'll be using **ChatGPT** to generate the text of a children's comic, and use **Stable Diffusion** to create pictures for the comic. Both ChatGPT and Stable Diffusion  are completely free. Lastly, we'll walk through deploying your comic as a website (yes, with a live URL :)) so you can share it with your friends 🌎
 
 This jam will take you from 0 to a ChatGPT and AI model "Hero":
-![](https://cloud-a10rlmpqz-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-a10rlmpqz-hack-club-bot.vercel.app/0image.png)
 
 As an example, here is an example of what your finished storybook may look like ([alex-gets-his-private-pilot-license.ganningxu.repl.co](https://alex-gets-his-private-pilot-license.ganningxu.repl.co))!
 
-![](https://cloud-d9ibqv1p3-hack-club-bot.vercel.app/0screen_recording_2023-08-01_at_12.26.59_pm__2_.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-d9ibqv1p3-hack-club-bot.vercel.app/0screen_recording_2023-08-01_at_12.26.59_pm__2_.gif)
 
 If you're interested, here's another comic that I made with ChatGPT and DALL-E ([robotics-mayhem.ganningxu.repl.co](https://robotics-mayhem.ganningxu.repl.co/))
-![](https://cloud-dau1tq7mx-hack-club-bot.vercel.app/0screen_recording_2023-08-08_at_7.06.00_pm.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-dau1tq7mx-hack-club-bot.vercel.app/0screen_recording_2023-08-08_at_7.06.00_pm.gif)
 
 Keep in mind that your result will be completely different. In fact, if it is the same, you're probably doing something wrong :) With that said, here are some resources that you may find helpful!
 
@@ -73,7 +73,7 @@ For more information on prompting basics, check out [promptingguide.ai](https://
 Next, we'll cover some common prompt engineering techniques. For each section, there will be a small challenge. You'll share your responses to each section on a Google Form that the club leader shares with you. You'll also have access to other people's responses, to stalk---I mean learn.
 
 Now, let's go into some specifics!
-![](https://cloud-o5nnqusk0-hack-club-bot.vercel.app/0giphy.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-o5nnqusk0-hack-club-bot.vercel.app/0giphy.gif)
 
 ### Zero-Shot Prompting
 > ❓ Using zero-shot prompting, come up with a sentence of your own and ask ChatGPT to classify it as spam or safe :)
@@ -127,12 +127,12 @@ When we won the game, we all started to farduddle in celebration.
 When using Chain-of-Thought prompting, you'll want to ask the model to **explain the intermediate reasoning steps** before giving the final answer. 
 
 Here's an [example](https://towardsdatascience.com/prompt-engineering-guide-for-data-analysts-54f480ba4d98):
-![](https://cloud-6v5c2pm6e-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-6v5c2pm6e-hack-club-bot.vercel.app/0image.png)
 
 Telling the model to solve it "step by step" helps it **think through its own answer**, giving more accurate results.
 
 Here's [another example](https://ai.googleblog.com/2022/05/language-models-perform-reasoning-via.html) (note that you can also "show" the model what step by step looks like):
-![](https://cloud-aaphlohmn-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-aaphlohmn-hack-club-bot.vercel.app/0image.png)
 
 ### Generated Knowledge Prompting
 > ❓ Using generated knowledge prompting, get ChatGPT to write a three paragraph essay on why comics and AI belong together. 
@@ -144,15 +144,15 @@ You can think of [GKP](https://arxiv.org/pdf/2110.08387.pdf) as the model **"sea
 These two screenshots are one example of GKP.
 
 [Generating the information](https://towardsdatascience.com/prompt-engineering-guide-for-data-analysts-54f480ba4d98) ("the search"):
-![](https://cloud-7rs0kqnrj-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-7rs0kqnrj-hack-club-bot.vercel.app/0image.png)
 
 [Using information to make answer](https://towardsdatascience.com/prompt-engineering-guide-for-data-analysts-54f480ba4d98) ("the answer"):
-![](https://cloud-5gt4oyd57-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-5gt4oyd57-hack-club-bot.vercel.app/0image.png)
 
 ### Self-Refine Prompting
 > ❓ Using self-refine prompting, ask ChatGPT to generate a function (in your choice of programming language) to play the game [fizzbuzz](https://en.wikipedia.org/wiki/Fizz_buzz#:~:text=Fizz%20buzz%20is%20a%20group,with%20the%20word%20%22fizzbuzz%22.). Though arguably Python is the best language hehe
 
-![](https://cloud-lfhygu0v3-hack-club-bot.vercel.app/0coding.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-lfhygu0v3-hack-club-bot.vercel.app/0coding.gif)
 
 You can think of SFP as the model "teaching itself". First, the user asks the model to provide an initial solution. Next, the user asks the model for problems with its original solution. Afterward, the user prompts the model to address the problems in its solution. This process can repeat until the user is happy with the result.
 
@@ -240,7 +240,7 @@ All three experts agree that the ball is in the bedroom.
 ## DAD JOKE COMPETITION
 AHA you didn't think you could skip this, did you >:) Here are the rules. Using the prompting techniques from above, generate five of your best dad jokes.
 
-![](https://cloud-54mgddtet-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-54mgddtet-hack-club-bot.vercel.app/0image.png)
 
 Your club leader will send a Google Form to everyone. At the end of the **five minutes**, submit your five jokes.
 
@@ -529,7 +529,7 @@ Prompt for Stable Diffusion:
 
 When feeding in a prompt to Stable Diffusion, you'll get four images. If you don't like them, feel free to adjust the prompt or click "Generate image" again. The image I liked the most was:
 
-![](https://cloud-41es9von4-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-41es9von4-hack-club-bot.vercel.app/0image.png)
 
 Make sure to save these images to your computer, as you'll be creating a website with them!
 
@@ -540,35 +540,35 @@ Continue doing this for the rest of the 8 sections.
 
 **Prompt 1**: Create a vibrant comic-style illustration featuring Alex, a determined high school student in North Carolina, who dreams of earning his private pilot license. Show Alex with a wide-eyed expression of excitement and wonder as he looks up at the sky filled with airplanes and clouds. Let his aviation enthusiast father be there, wearing a pilot's cap and sharing in his son's enthusiasm, supporting him in his journey. Surround them with motivational aviation posters and aviation-themed décor in the background, symbolizing Alex's aspirations and determination to soar high in the sky. Make sure to capture the essence of Alex's passion for flying and his desire to prove himself, both to his father and to himself, in the details of their expressions and body language.
     
-![](https://cloud-41es9von4-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-41es9von4-hack-club-bot.vercel.app/0image.png)
 
 **Prompt 2**: Create an expressive comic-style illustration depicting Alex's journey of setting his sights on earning his private pilot license. Show Alex in his room, surrounded by aviation posters, airplane models, and flight manuals, symbolizing his determination and focus on his dream. Capture the conflict of emotions on his face as he grapples with self-doubt and worries about the challenges ahead. Let his reflection in a mirror reveal a mix of determination and uncertainty, highlighting his inner struggle. Meanwhile, show his aviation enthusiast father by his side, offering encouraging words and support, showcasing their close bond. In the background, include scenes of Alex researching flight schools and requirements online, interacting with the local aviation community, and receiving valuable guidance, symbolizing the network of support he discovers. The illustration should portray both the emotional journey and the determination he gains from his support system, emphasizing the resilience of his character and the hope for a bright future in aviation
     
-![](https://cloud-htzl0ftuj-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-htzl0ftuj-hack-club-bot.vercel.app/0image.png)
 
 **Prompt 3**: Create an engaging comic-style illustration showcasing Alex's exciting journey as he enrolls in a reputable local flight school to pursue his dream of becoming a pilot. Illustrate the moment he meets his flight instructor, Captain Johnson, who exudes an air of authority and experience. Show Captain Johnson with a caring yet firm expression, emphasizing his strict yet nurturing teaching style. As Alex interacts with his fellow aviation enthusiasts, Sarah and Mike, illustrate the budding friendship among the trio, capturing their shared passion for flying. They are seen exchanging aviation books, sharing stories, and cheering each other on during their flight training. The illustration should portray a sense of camaraderie and mutual support, highlighting the bond they form over their common aspirations and dedication to aviation. In the background, include scenes of the flight school's hangar, airplanes, and aviation-themed decorations, setting the stage for their exciting journey into the world of aviation
     
-![](https://cloud-i1teccyai-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-i1teccyai-hack-club-bot.vercel.app/0image.png)
     
 **Prompt 4**: Create a vibrant comic-style illustration portraying the challenges and triumphs of Alex's flight training journey. Show Alex in the cockpit of a training aircraft, facing various difficulties while practicing complex flight maneuvers. Illustrate his expressions, body language, and interactions with his flight instructor, Captain Johnson, to convey the emotional ups and downs of the learning process. In contrast, depict heartwarming scenes of Alex's family and friends offering support and encouragement, standing by him through setbacks. Showcase a transformative moment where Alex's determination begins to shine through, as he gains confidence and embraces the learning process. Use dynamic poses and facial expressions to evoke empathy and admiration for Alex's resilience. In the background, include scenes of the flight school environment and other student pilots practicing, emphasizing the sense of community and shared experiences in aviation. The illustration should capture the essence of Alex's growth as a pilot, the power of determination, and the importance of a support system in overcoming challenges
 
-![](https://cloud-ih2dlt9xb-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-ih2dlt9xb-hack-club-bot.vercel.app/0image.png)
     
 **Prompt 5**: Craft a captivating comic-style illustration capturing the momentous occasion of Alex's first solo flight. Show Alex in the cockpit of a training aircraft, dressed in his flight gear, with a mix of excitement and nervousness evident on his face. Illustrate the aircraft's controls, surrounding instruments, and the vast sky outside, symbolizing the responsibility and freedom he feels as he takes control of the aircraft alone. Depict his flight instructor, Captain Johnson, watching from the ground with pride and confidence in his student's abilities. Use dynamic and expressive poses to convey the emotional intensity of the moment. In the background, include elements of the flight school environment, such as other planes and student pilots, adding to the sense of accomplishment and community. The illustration should capture the essence of Alex's personal growth, boosted confidence, and unwavering passion for aviation as he embarks on this significant turning point in his journey as a pilot."
 
-![](https://cloud-3wvlrjhsi-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-3wvlrjhsi-hack-club-bot.vercel.app/0image.png)
     
 **Prompt 6**: Create a compelling comic-style illustration portraying the build-up to Alex's flight test. Show Alex and Captain Johnson in intense flight training sessions, with Alex's expressions conveying his mounting anxiety and determination to excel. Illustrate the cockpit environment, with flight instruments and checklists, to depict the preparation and focus required for the test. Highlight moments of perseverance and discipline as Alex dedicates himself to rigorous practice. Use Captain Johnson's mentorship and supportive gestures to show the valuable life lessons he imparts to Alex, emphasizing the importance of staying calm under pressure. Incorporate visual cues, such as a calendar marking the approaching test date, to build suspense. In the background, include scenes of the flight school and other student pilots, reflecting the atmosphere of anticipation and determination. The illustration should capture the emotional intensity and the valuable growth experiences that Alex undergoes in preparation for the flight test, showcasing his resilience and commitment to becoming a skilled pilot.
     
-![](https://cloud-6y6x41yaf-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-6y6x41yaf-hack-club-bot.vercel.app/0image.png)
     
 **Prompt 7**: Create an intense comic-style illustration capturing the pivotal flight test day for Alex. Show Alex in the cockpit of the aircraft, surrounded by stormy skies and turbulent weather, symbolizing the unexpected challenges he faces. Illustrate his focused expression and confident posture as he navigates through the turbulence, demonstrating his proficiency as a pilot. Use dynamic poses and flight maneuvers to convey the intensity of the situation. Depict the aircraft's controls and instruments to emphasize his decision-making skills under pressure. Show Captain Johnson observing from the ground with a mix of concern and pride, reflecting the stakes of the test. As Alex applies everything he's learned, illustrate moments of growth as both a pilot and an individual, capturing the sense of achievement and self-assurance. In the background, include elements of the flight school and other planes, adding to the immersive atmosphere of the test environment. The illustration should showcase the test's challenging nature, the demonstration of Alex's growth, and the significance of this day in his journey as a skilled pilot
 
-![](https://cloud-m3sbbrf3q-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-m3sbbrf3q-hack-club-bot.vercel.app/0image.png)
     
 **Prompt 8**: Create a triumphant comic-style illustration capturing the moment when Alex successfully completes his flight test and earns his private pilot license. Show Alex in the cockpit of the aircraft, with a jubilant expression and a sense of accomplishment evident on his face. Illustrate the flight test examiner presenting him with the pilot license, symbolizing the achievement of his dream. Use dynamic poses and a celebratory atmosphere to convey the excitement of the moment. In the background, include scenes of North Carolina's landscape, with the sky painted in warm hues during sunset or sunrise, signifying the beginning of a new chapter in Alex's life as a pilot. Show his family and friends cheering from the ground, reflecting the support and love that made this accomplishment possible. The illustration should portray the culmination of Alex's hard work, determination, and growth throughout the journey, showcasing the importance of pursuing one's dreams and the joy of achieving them with the backing of loved ones.
     
-![](https://cloud-1ns1fl309-hack-club-bot.vercel.app/0image.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-1ns1fl309-hack-club-bot.vercel.app/0image.png)
     
 </details>
 
@@ -581,13 +581,13 @@ Also, if you have no experience with web development, don't panic, we'll walk yo
 1. First, using the [provided site template](https://replit.com/@GanningXu/ComicAiSiteTemplate?v=1), click "Fork"
 2. Name the template anything you'd like. For example, you could use the title of your comic.
 3. Now you should have an editable version that looks like this!
-![](https://cloud-h8lzbpzlx-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.39.15_pm.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-h8lzbpzlx-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.39.15_pm.png)
 
 **Upload your images**
 1. In the left file pane, click the three dots, and then click "Upload File":
-![](https://cloud-hq2einq2r-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.41.23_pm.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-hq2einq2r-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.41.23_pm.png)
 2. Using your file explorer, upload all the saved images that Stable Diffusion (or whichever image generator you used) created. After uploading, your file pane should look something like this (of course, your files may have different names).
-![](https://cloud-ebgrxv038-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.42.37_pm.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-ebgrxv038-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.42.37_pm.png)
 
 **Editing the HTML file**
 1. Let's get the images and text you uploaded onto your site!
@@ -601,16 +601,16 @@ Also, if you have no experience with web development, don't panic, we'll walk yo
 
 For example, since the filename of my first image is called `img1.png` and filename of my second image is `img2.jpeg`, my `index.html` file looks like: 
 
-![](https://cloud-mctosy4p1-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.50.44_pm.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-mctosy4p1-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.50.44_pm.png)
 
 **Getting the URL**
 1. To get the sharable URL for your new site, first click the green "Run" button at the top of your screen.
 2. Next, find the URL of the "embeded" browser, where your site is showing, and copy that URL, as shown below!
-![](https://cloud-90323bbsa-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.58.02_pm.png)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-90323bbsa-hack-club-bot.vercel.app/0screenshot_2023-07-26_at_9.58.02_pm.png)
 
 Feel free to share that URL with friends/family :) HOORAY, YOU DID IT!!!
 
-![](https://cloud-5y24e2iqg-hack-club-bot.vercel.app/0minions-yay.gif)
+![](https://cdn.hackclub.com/rescue?url=https://cloud-5y24e2iqg-hack-club-bot.vercel.app/0minions-yay.gif)
 
 ## Extensions
 If you're feeling adventurous (or just want to learn something new), here are some extensions you can try out!

--- a/jams/singles/web-ar/en-US.md
+++ b/jams/singles/web-ar/en-US.md
@@ -3,7 +3,7 @@ title: 'Mastering the Matrix: Crafting Your Own Web-based AR App'
 description: >
   This guide outlines how to create a virtual reality scene using A-Frame, a web framework for building VR experiences. It discusses a component-based architecture to manage complexity and improve reusability.
 contributor: 'DevIos01'
-thumbnail: 'https://cloud-otgp3nnas-hack-club-bot.vercel.app/0000thumbnail-jam__1__50.webp'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-otgp3nnas-hack-club-bot.vercel.app/0000thumbnail-jam__1__50.webp'
 timeEstimate: '60 Min'
 difficulty: 'Beginner'
 keywords: 'Web, Magic, AR, Ar.js'
@@ -16,7 +16,7 @@ poster: ''
 video: ''
 slug: 'web-ar'
 ---
-![https://cloud-4vl3zrzew-hack-club-bot.vercel.app/7image.gif](https://cloud-4vl3zrzew-hack-club-bot.vercel.app/7image.gif)
+![https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/7image.gif](https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/7image.gif)
 
 Imagine a universe where you hold the magic to create your own dimensions and craft the castles of your dreams. **Today, we'll embark on a journey through the heart of VR development by constructing our very own floating virtual lands and join forces by integrating them into a shared celestial town.**
 
@@ -28,7 +28,7 @@ In this workshop, we'll not only dive into the futuristic world of Augmented Rea
 
 You should have a basic understanding of HTML, CSS, and JavaScript. If you can say "Hello, World!" in these languages, you're ready to conquer the AR world.
 
-![https://cloud-4vl3zrzew-hack-club-bot.vercel.app/6image__1_.gif](https://cloud-4vl3zrzew-hack-club-bot.vercel.app/6image__1_.gif)
+![https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/6image__1_.gif](https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/6image__1_.gif)
 
 ## Tools
 
@@ -41,12 +41,12 @@ You should have a basic understanding of HTML, CSS, and JavaScript. If you can s
 
 1. Head over to [Argument Reality Template](https://replit.com/@DevIos01/WebBasedArgumentReality-Template) and click "fork". Then, sign up or sign in, which will load the new dashboard where you can do everything.
 
-![Gif of how to fork the project](https://cloud-4vl3zrzew-hack-club-bot.vercel.app/5ar__1_.gif)
+![Gif of how to fork the project](https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/5ar__1_.gif)
 
 
 1. Take a moment to look around and familiarize yourself with this lovely dashboard.
 
-![image (19).png](https://cloud-4vl3zrzew-hack-club-bot.vercel.app/4image__19___1_.png)
+![image (19).png](https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/4image__19___1_.png)
 
 **Source Code:** The canvas where all your creativity takes the form of code.
 
@@ -81,7 +81,7 @@ You should have a basic understanding of HTML, CSS, and JavaScript. If you can s
 - **Go to line:** **`Ctrl`** + **`G`**
 - **Autocomplete:** **`Ctrl`** + **`Space`**
 
-![https://cloud-4vl3zrzew-hack-club-bot.vercel.app/3image__2_.gif](https://cloud-4vl3zrzew-hack-club-bot.vercel.app/3image__2_.gif)
+![https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/3image__2_.gif](https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/3image__2_.gif)
 
 Steps
 
@@ -109,7 +109,7 @@ Picture this - you're a wizard, and you're about to cast your first spell. You r
 
 ```
 
-![https://cloud-4vl3zrzew-hack-club-bot.vercel.app/2image__3_.gif](https://cloud-4vl3zrzew-hack-club-bot.vercel.app/2image__3_.gif)
+![https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/2image__3_.gif](https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/2image__3_.gif)
 
 We're essentially incorporating these 'spells' into our web page to breathe interactivity into it. Without them, our web page would be a static set. But with JS (our magic ink), we make the elements come alive, move, disappear, change colors, and much more!
 
@@ -162,7 +162,7 @@ Lastly, the magician leaves a message, guiding the audience on how to partake in
       color="red" visible="true"></a-text>
 ```
 
-![https://cloud-4vl3zrzew-hack-club-bot.vercel.app/1image__4_.gif](https://cloud-4vl3zrzew-hack-club-bot.vercel.app/1image__4_.gif)
+![https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/1image__4_.gif](https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/1image__4_.gif)
 
 When these ingredients come together in our digital cauldron, a delightful AR experience is brewed! The 3D duck majestically appears, twirling and spinning in all its glory. Every magician has more than one trick up their sleeve, and so will we! Stay tuned!🎩🔮
 
@@ -219,4 +219,4 @@ Alright, conjuring one 3D duck is cool, but you know what's cooler? Conjuring mu
 
 We've now built a basic AR application with multiple 3D models, and we didn't even need goofy glasses! Not only do we know how to set up an AR scene, but we can also add multiple 3D models to the scene and make them come alive. We've mastered the basics and we're ready to create our own digital universe. Remember, in the world of AR, the only limit is your imagination. Keep coding and keep exploring!
 
-![https://cloud-4vl3zrzew-hack-club-bot.vercel.app/0image__5_.gif](https://cloud-4vl3zrzew-hack-club-bot.vercel.app/0image__5_.gif)
+![https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/0image__5_.gif](https://cdn.hackclub.com/rescue?url=https://cloud-4vl3zrzew-hack-club-bot.vercel.app/0image__5_.gif)

--- a/jams/singles/wizard-orpheus/en-US.md
+++ b/jams/singles/wizard-orpheus/en-US.md
@@ -3,14 +3,14 @@ title: 'Make an AI Game in 40 Lines'
 description: >
     In this Jam, you will make your own AI Game in 40 lines of code using Wizard Orpheus! Wizard Orpheus is a JavaScript library that makes it easy peasy to build AI apps in JavaScript with minimal prior knowledge!
 contributor: 'zachlatta'
-thumbnail: 'https://cloud-njbdwayky-hack-club-bot.vercel.app/00rugmerchant__1_.png'
+thumbnail: 'https://cdn.hackclub.com/rescue?url=https://cloud-njbdwayky-hack-club-bot.vercel.app/00rugmerchant__1_.png'
 timeEstimate: '60 Min'
 difficulty: 'Beginner'
 keywords: 'AI, Web'
 language: 'JavaScript'
 presentation: ''
 presentationPlay: 'https://www.figma.com/proto/NbF4B2LzkN1GSYEEuSFkpp/AI-Orpheus?page-id=0%3A1&type=design&node-id=1-2&viewport=411%2C392%2C0.3&t=lAQeAkJIJzYIFPzn-1&scaling=scale-down-width&mode=design'
-presentationPDF: 'https://cloud-7vhdadbef-hack-club-bot.vercel.app/0ai_orpheus_compressed__1_.pdf'
+presentationPDF: 'https://cdn.hackclub.com/rescue?url=https://cloud-7vhdadbef-hack-club-bot.vercel.app/0ai_orpheus_compressed__1_.pdf'
 notes: 'https://github.com/hackclub/wizard-orpheus/blob/main/README.md'
 poster: ''
 video: ''
@@ -34,10 +34,10 @@ You will get to come up with your own story, game variables, and fun mechanics. 
 Visit [hack.club/wow-starter](https://hack.club/wow-starter
 ) and tap Fork & Run. You'll need to create a Replit account for this to work. 
 
-![Wizard Orpheus Fork & Run Gif](https://cloud-rfnb1efui-hack-club-bot.vercel.app/0wizard-orpheus-fork-and-run.gif)
+![Wizard Orpheus Fork & Run Gif](https://cdn.hackclub.com/rescue?url=https://cloud-rfnb1efui-hack-club-bot.vercel.app/0wizard-orpheus-fork-and-run.gif)
 ## Add ability for users to send a message
 Currently when the user taps enter... 
-![user tapping enter](https://cloud-wd3hweveh-hack-club-bot.vercel.app/0noenter.gif)
+![user tapping enter](https://cdn.hackclub.com/rescue?url=https://cloud-wd3hweveh-hack-club-bot.vercel.app/0noenter.gif)
 
 It does not send the message! Let's change that
 
@@ -66,7 +66,7 @@ document.getElementById('input').addEventListener('keyup', function(e) {
 
 This code is giving the user the ability to send a message when they tap Enter. It also clears out the input afterwards so that the input is ready for the next message. 
 
-![new code segment shown working](https://cloud-prej9qe5y-hack-club-bot.vercel.app/0newcodesegment.gif)
+![new code segment shown working](https://cdn.hackclub.com/rescue?url=https://cloud-prej9qe5y-hack-club-bot.vercel.app/0newcodesegment.gif)
 
 ## Add ability for bot to respond
 We're able to send a message, but we're not currently getting a response. 
@@ -82,7 +82,7 @@ myGame.botAction('respond', 'Send a text response to the user', { message: 'What
 
 Now we're able to get a response to our messages!
 
-![getting response](https://cloud-ajjskyyoq-hack-club-bot.vercel.app/0getmeout.gif)
+![getting response](https://cdn.hackclub.com/rescue?url=https://cloud-ajjskyyoq-hack-club-bot.vercel.app/0getmeout.gif)
 
 ## Create a variable to keep score
 To add more complexity to our game, we can add variables. Variables can be anything from the mood of the character you're talking with to the darkness of the room you're in. 
@@ -101,7 +101,7 @@ document.getElementById('score').innerHTML = data.currentVariables.score.value
 
 Keep in mind that you're *adding to the bot action* instead of creating a whole new bot action.
 
-![Change my score](https://cloud-3so5m9g4f-hack-club-bot.vercel.app/0changemyscore.gif)
+![Change my score](https://cdn.hackclub.com/rescue?url=https://cloud-3so5m9g4f-hack-club-bot.vercel.app/0changemyscore.gif)
 
 
 ## Update the background with variables
@@ -119,7 +119,7 @@ myGame.botAction('respond', 'Send a text response to the user', { message: 'What
 })
 ```
 
-![Darken screen](https://cloud-detca5vdf-hack-club-bot.vercel.app/0darkerscreen.gif)
+![Darken screen](https://cdn.hackclub.com/rescue?url=https://cloud-detca5vdf-hack-club-bot.vercel.app/0darkerscreen.gif)
 
 ## Customize prompt to make your own game
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -69,7 +69,7 @@ export default function App({
         title="Jams"
         description="Collaborative coding workshops for clubs where sparks ignite,
         fears dissolve, and inventions come to life."
-        image="https://cloud-fryy8trec-hack-club-bot.vercel.app/00hack_club_assemble_ltnj_00622.jpg"
+        image="https://cdn.hackclub.com/rescue?url=https://cloud-fryy8trec-hack-club-bot.vercel.app/00hack_club_assemble_ltnj_00622.jpg"
         color="#ec3750"
       />
       <Component {...pageProps} />

--- a/pages/guides/index.js
+++ b/pages/guides/index.js
@@ -85,7 +85,7 @@ export default function Index(props) {
             position: 'absolute',
             mixBlendMode: 'color-burn'
           }}
-          src="https://cloud-omdlqtlig-hack-club-bot.vercel.app/0rectangle_60.png"
+          src="https://cdn.hackclub.com/rescue?url=https://cloud-omdlqtlig-hack-club-bot.vercel.app/0rectangle_60.png"
           alt=""
         />
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -684,7 +684,7 @@ export default function Index(props) {
             position: 'absolute',
             mixBlendMode: 'color-burn'
           }}
-          src="https://cloud-omdlqtlig-hack-club-bot.vercel.app/0rectangle_60.png"
+          src="https://cdn.hackclub.com/rescue?url=https://cloud-omdlqtlig-hack-club-bot.vercel.app/0rectangle_60.png"
           alt=""
         />
 


### PR DESCRIPTION
Points **796 retired-CDN asset references** across **63 files** at the current CDN's lookup endpoint, `cdn.hackclub.com/rescue?url=<original>`.

The old Vercel and Hetzner origins are being retired. `/rescue` resolves an original URL to wherever that file now lives on the v4 CDN, so wrapping the existing URL keeps these assets loading without moving any bytes or re-uploading anything.

```diff
- ![screenshot](https://cloud-abc123-hack-club-bot.vercel.app/0image.png)
+ ![screenshot](https://cdn.hackclub.com/rescue?url=https://cloud-abc123-hack-club-bot.vercel.app/0image.png)
```

### Scope

- 796 references rewritten across 63 files.
- Text references only — no image bytes, no filenames, no uploads, no layout changes.
- Every change is a pure URL-for-URL substitution, verified programmatically: masking the rewritten spans in both the original and the result yields byte-identical documents, so no surrounding markup was touched.
- Original URLs are preserved verbatim inside the `url=` parameter, so this is fully reversible and nothing is lost.

### Note: 128 of these will still 404 for now

Those files are already gone from the old CDN (the source URLs 404 and `/rescue` has no record of them), so they are broken today and stay broken. Wrapping them costs nothing and means they start working automatically if the assets are ever recovered and mapped, which a bare dead URL would never do.